### PR TITLE
[DO NOT MERGE] feat: add Aplifisa integration fields and filters to openapi spec [QUI-11439]

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1557,6 +1557,176 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /{owner_slug}/money_accounts:
+    get:
+      operationId: listMoneyAccounts
+      summary: List bank accounts
+      tags: [MoneyAccounts]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Paginated list of bank accounts
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MoneyAccountResource"
+                  meta:
+                    $ref: "#/components/schemas/PaginationMeta"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /{owner_slug}/money_accounts/{id}:
+    get:
+      operationId: getMoneyAccount
+      summary: Show bank account
+      tags: [MoneyAccounts]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Bank account found
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/MoneyAccountResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /{owner_slug}/money_entries:
+    get:
+      operationId: listMoneyEntries
+      summary: List bank movements
+      tags: [MoneyEntries]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - name: filter[date][from]
+          in: query
+          schema:
+            type: string
+            format: date
+          description: >
+            Start of date range (YYYY-MM-DD).
+            Must be provided together with filter[date][to] — returns 400 if only one is present.
+        - name: filter[date][to]
+          in: query
+          schema:
+            type: string
+            format: date
+          description: >
+            End of date range (YYYY-MM-DD).
+            Must be provided together with filter[date][from] — returns 400 if only one is present.
+      responses:
+        "200":
+          description: Paginated list of bank movements
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MoneyEntryResource"
+                  meta:
+                    $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          description: >
+            Bad request. Returned when only one of filter[date][from] /
+            filter[date][to] is provided, or the date format is invalid.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /{owner_slug}/money_entries/{id}:
+    get:
+      operationId: getMoneyEntry
+      summary: Show bank movement
+      tags: [MoneyEntries]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Bank movement found
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/MoneyEntryResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /{owner_slug}/liquidations:
+    get:
+      operationId: listLiquidations
+      summary: List reconciliation links
+      tags: [Liquidations]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Paginated list of reconciliation links
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LiquidationResource"
+                  meta:
+                    $ref: "#/components/schemas/PaginationMeta"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /{owner_slug}/liquidations/{id}:
+    get:
+      operationId: getLiquidation
+      summary: Show reconciliation link
+      tags: [Liquidations]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Reconciliation link found
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/LiquidationResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 # ═════════════════════════════════════════════════════════════════════════
 # Components
 # ═════════════════════════════════════════════════════════════════════════
@@ -2845,6 +3015,128 @@ components:
           properties:
             book_entry:
               $ref: "#/components/schemas/RelationshipLinkage"
+    MoneyAccountResource:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [money_accounts]
+        attributes:
+          $ref: "#/components/schemas/MoneyAccountAttributes"
+
+    MoneyAccountAttributes:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Display name of the bank account.
+          example: "Cuenta corriente BBVA"
+        accounting_number:
+          type: string
+          description: Full concatenated accounting ledger code for this bank account (all digits).
+          example: "57200001"
+        currency:
+          type: string
+          description: Currency of the account. Always "eur".
+          example: "eur"
+
+    MoneyEntryResource:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [money_entries]
+        attributes:
+          $ref: "#/components/schemas/MoneyEntryAttributes"
+
+    MoneyEntryAttributes:
+      type: object
+      properties:
+        concept:
+          type: string
+          description: Description or reference of the bank movement.
+          example: "Transferencia cliente ABC"
+        amount:
+          type: string
+          description: >
+            Movement amount as a decimal string.
+            Positive = collection (cobro); negative = payment (pago).
+          example: "1500.00"
+        transaction_date:
+          type: string
+          format: date
+          description: Date the movement was recorded (YYYY-MM-DD).
+          example: "2025-03-15"
+        status:
+          type: string
+          enum: [pending, reconciled, partially_reconciled, overconciled]
+          description: >
+            Reconciliation status of the movement.
+            pending = not yet matched to any document;
+            reconciled = fully matched;
+            partially_reconciled = partially matched;
+            overconciled = matched amount exceeds the movement amount.
+        money_account_id:
+          type: integer
+          description: ID of the bank account this movement belongs to.
+        money_account_accounting_number:
+          type: string
+          nullable: true
+          description: Full concatenated accounting ledger code of the associated bank account.
+          example: "57200001"
+
+    LiquidationResource:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [liquidations]
+        attributes:
+          $ref: "#/components/schemas/LiquidationAttributes"
+
+    LiquidationAttributes:
+      type: object
+      properties:
+        amount:
+          type: string
+          description: Reconciled amount for this link, as a decimal string.
+          example: "500.00"
+        money_entry_id:
+          type: integer
+          nullable: true
+          description: >
+            ID of the bank movement. Null for manual reconciliations
+            not linked to a bank movement.
+        book_entry_id:
+          type: integer
+          description: ID of the settled document (invoice, paysheet, etc.).
+        date:
+          type: string
+          format: date
+          nullable: true
+          description: Date of the reconciliation link (YYYY-MM-DD).
+        book_entry_number:
+          type: string
+          description: Document number of the settled book entry (e.g. "F-2025-001").
+        money_account_accounting_number:
+          type: string
+          nullable: true
+          description: >
+            Full concatenated accounting ledger code of the bank account
+            associated with the movement. Null when money_entry_id is null.
+          example: "57200001"
+        book_entry_counterpart_accounting_number:
+          type: string
+          description: >
+            Full concatenated accounting ledger code of the counterpart
+            (contact) on the settled document.
+          example: "43000001"
 
   # ── Responses ──────────────────────────────────────────────────────────
   responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -344,6 +344,11 @@ paths:
           schema:
             type: integer
           description: Filter by economic activity ID
+        - name: filter[economic_activity_epigraph]
+          in: query
+          schema:
+            type: string
+          description: Filter by economic activity epigraph
         - name: filter[verifactu_status]
           in: query
           schema:
@@ -432,6 +437,11 @@ paths:
           schema:
             type: integer
           description: Filter by economic activity ID
+        - name: filter[economic_activity_epigraph]
+          in: query
+          schema:
+            type: string
+          description: Filter by economic activity epigraph
         - name: filter[verifactu_status]
           in: query
           schema:
@@ -787,6 +797,11 @@ paths:
           schema:
             type: integer
           description: Filter by economic activity ID
+        - name: filter[economic_activity_epigraph]
+          in: query
+          schema:
+            type: string
+          description: Filter by economic activity epigraph
       responses:
         "200":
           description: Paginated list of additional income
@@ -928,6 +943,11 @@ paths:
           schema:
             type: integer
           description: Filter by economic activity ID
+        - name: filter[economic_activity_epigraph]
+          in: query
+          schema:
+            type: string
+          description: Filter by economic activity epigraph
         - name: filter[verifactu_status]
           in: query
           schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1802,6 +1802,20 @@ components:
           type: string
           nullable: true
           description: Modelo 190 subkey for this retention. Placeholder — not yet populated.
+        tax_form:
+          type: string
+          nullable: true
+          description: "IRPF/VAT reporting form code. Values: 00 (non-EU import), 01 (standard retention), 02 (EU goods), 03 (transport), 05 (other services), 09 (1% retention), 11 (EU services). Null if not applicable."
+        equalization_tax_rate:
+          type: string
+          nullable: true
+          description: "Equivalence surcharge rate for this item's VAT rate (e.g. \"5.2\" for 21% VAT, \"1.4\" for 10% VAT). Null if no surcharge."
+        equalization_tax_amount:
+          type: string
+          description: Equivalence surcharge amount for this line item. "0.0" if none.
+        retention_rate:
+          type: number
+          description: Retention percentage for this line item (e.g. 21, 15, 7). 0 if no retention.
 
     ItemWritableAttributes:
       type: object
@@ -2068,11 +2082,11 @@ components:
         document_type:
           type: string
           nullable: true
-          description: SII fiscal document type (F1/F2 for normal, R1–R5 for credit notes). Placeholder — not yet populated.
+          description: "Verifactu document type code: F1 (standard invoice), F2 (simplified invoice), R1–R5 (credit notes)."
         tax_form:
           type: string
           nullable: true
-          description: Tax form reference (e.g. 303, 130). Placeholder — not yet populated.
+          description: Tax form reference (e.g. 303, 130).
         contact_account_code:
           type: string
           nullable: true
@@ -2097,31 +2111,57 @@ components:
         equalization_tax_rate:
           type: number
           nullable: true
-          description: Equalization surcharge rate. Placeholder — not yet populated.
+          description: Equalization surcharge rate.
         rectification_type:
           type: string
           nullable: true
-          description: Veri*factu rectification type. Placeholder.
+          description: "For credit notes: S (full substitution) or I (by differences). Null for non-credit entries."
         rectification_kind:
           type: string
           nullable: true
-          description: Veri*factu rectification kind. Placeholder.
+          description: "For credit notes: R1–R5 matching document_type. Null for non-credit entries."
         operation_classification:
-          type: string
+          type: array
           nullable: true
-          description: Veri*factu operation classification. Placeholder.
+          description: Operation classification per VAT rate. One element per distinct rate in the document's current line items.
+          items:
+            type: object
+            properties:
+              vat:
+                type: number
+                description: VAT rate percentage (e.g. 21.0, 10.0, 0.0)
+              value:
+                type: string
+                nullable: true
+                description: "Classification code: S1, S2, N1, N2, or null (exempt — see exempt_operation_types)"
         exempt_operation_type:
-          type: string
-          nullable: true
-          description: Veri*factu exempt operation type. Placeholder.
+          type: array
+          description: Exemption type per VAT rate. One element per distinct exempt rate. Empty array when no exempt items.
+          items:
+            type: object
+            properties:
+              vat:
+                type: number
+                description: VAT rate percentage (typically 0.0 for exempt items)
+              value:
+                type: string
+                description: "Exemption code: E1, E2, E3, E5, or E6"
         regime_key:
-          type: string
-          nullable: true
-          description: Veri*factu regime key. Placeholder.
+          type: array
+          description: VAT regime key per rate. One element per distinct rate in the document's current line items.
+          items:
+            type: object
+            properties:
+              vat:
+                type: number
+                description: VAT rate percentage
+              value:
+                type: string
+                description: "Regime key code (e.g. \"01\", \"02\", \"08\") or empty string when not determined"
         operation_description:
           type: string
           nullable: true
-          description: Veri*factu operation description. Placeholder.
+          description: "Human-readable summary of line items: \"account - concept - amount€\" per item, joined with \" | \". Max 500 characters."
 
     BookEntryResource:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2154,9 +2154,6 @@ components:
               type: string
             vat_amount:
               type: string
-            retention_amount:
-              type: string
-              description: Total retention (IRPF) amount withheld. Also present on all book entry types via BookEntryAttributes.
             last_sent_at:
               type: string
               format: date-time
@@ -2312,8 +2309,6 @@ components:
               type: string
             vat_amount:
               type: string
-            retention_amount:
-              type: string
             notes:
               type: string
               nullable: true
@@ -2430,8 +2425,6 @@ components:
             total_amount_without_taxes:
               type: string
             vat_amount:
-              type: string
-            retention_amount:
               type: string
             notes:
               type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2154,6 +2154,9 @@ components:
               type: string
             vat_amount:
               type: string
+            retention_amount:
+              type: string
+              description: Total retention (IRPF) amount withheld. Also present on all book entry types via BookEntryAttributes.
             last_sent_at:
               type: string
               format: date-time

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,6 +61,12 @@ tags:
     description: Accounting subcategories
   - name: Attachments
     description: File attachments for book entries
+  - name: Money Accounts
+    description: Bank accounts linked to the owner
+  - name: Money Entries
+    description: Bank movements for a given bank account
+  - name: Liquidations
+    description: Reconciliation links between bank movements and documents
 
 paths:
   # ── Users ──────────────────────────────────────────────────────────────
@@ -1561,7 +1567,7 @@ paths:
     get:
       operationId: listMoneyAccounts
       summary: List bank accounts
-      tags: [MoneyAccounts]
+      tags: [Money Accounts]
       parameters:
         - $ref: "#/components/parameters/OwnerSlug"
         - $ref: "#/components/parameters/AcceptHeader"
@@ -1587,7 +1593,7 @@ paths:
     get:
       operationId: getMoneyAccount
       summary: Show bank account
-      tags: [MoneyAccounts]
+      tags: [Money Accounts]
       parameters:
         - $ref: "#/components/parameters/OwnerSlug"
         - $ref: "#/components/parameters/AcceptHeader"
@@ -1611,7 +1617,7 @@ paths:
     get:
       operationId: listMoneyEntries
       summary: List bank movements
-      tags: [MoneyEntries]
+      tags: [Money Entries]
       parameters:
         - $ref: "#/components/parameters/OwnerSlug"
         - $ref: "#/components/parameters/AcceptHeader"
@@ -1657,7 +1663,7 @@ paths:
     get:
       operationId: getMoneyEntry
       summary: Show bank movement
-      tags: [MoneyEntries]
+      tags: [Money Entries]
       parameters:
         - $ref: "#/components/parameters/OwnerSlug"
         - $ref: "#/components/parameters/AcceptHeader"
@@ -3022,7 +3028,7 @@ components:
           type: string
         type:
           type: string
-          enum: [money_accounts]
+          const: money_accounts
         attributes:
           $ref: "#/components/schemas/MoneyAccountAttributes"
 
@@ -3039,8 +3045,8 @@ components:
           example: "57200001"
         currency:
           type: string
-          description: Currency of the account. Always "eur".
-          example: "eur"
+          const: eur
+          description: Currency of the account.
 
     MoneyEntryResource:
       type: object
@@ -3049,7 +3055,7 @@ components:
           type: string
         type:
           type: string
-          enum: [money_entries]
+          const: money_entries
         attributes:
           $ref: "#/components/schemas/MoneyEntryAttributes"
 
@@ -3096,7 +3102,7 @@ components:
           type: string
         type:
           type: string
-          enum: [liquidations]
+          const: liquidations
         attributes:
           $ref: "#/components/schemas/LiquidationAttributes"
 
@@ -3140,6 +3146,15 @@ components:
 
   # ── Responses ──────────────────────────────────────────────────────────
   responses:
+    BadRequest:
+      description: Bad request — invalid or missing parameters
+      content:
+        application/vnd.quipu.v1+json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            errors:
+              - detail: filter[date][from] and filter[date][to] must both be present
     Unauthorized:
       description: Authentication required or token invalid
       content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -339,6 +339,17 @@ paths:
           schema:
             type: string
           description: Search term for field-level query filter
+        - name: filter[economic_activity_id]
+          in: query
+          schema:
+            type: integer
+          description: Filter by economic activity ID
+        - name: filter[verifactu_status]
+          in: query
+          schema:
+            type: string
+            enum: [noop, draft, final, sent_aeat, approved_aeat, approved_with_errors_aeat, rejected_aeat]
+          description: Filter by Verifactu submission status
         - name: sort
           in: query
           schema:
@@ -416,6 +427,17 @@ paths:
           schema:
             type: string
           description: Search term for field-level query filter
+        - name: filter[economic_activity_id]
+          in: query
+          schema:
+            type: integer
+          description: Filter by economic activity ID
+        - name: filter[verifactu_status]
+          in: query
+          schema:
+            type: string
+            enum: [noop, draft, final, sent_aeat, approved_aeat, approved_with_errors_aeat, rejected_aeat]
+          description: Filter by Verifactu submission status
       responses:
         "200":
           description: Paginated list of invoices
@@ -760,6 +782,11 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludeAdditionalIncome"
+        - name: filter[economic_activity_id]
+          in: query
+          schema:
+            type: integer
+          description: Filter by economic activity ID
       responses:
         "200":
           description: Paginated list of additional income
@@ -896,6 +923,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludePaysheet"
+        - name: filter[economic_activity_id]
+          in: query
+          schema:
+            type: integer
+          description: Filter by economic activity ID
+        - name: filter[verifactu_status]
+          in: query
+          schema:
+            type: string
+            enum: [noop, draft, final, sent_aeat, approved_aeat, approved_with_errors_aeat, rejected_aeat]
+          description: Filter by Verifactu submission status
       responses:
         "200":
           description: Paginated list of paysheets
@@ -1836,6 +1874,10 @@ components:
             Computed per-request from the caller's abilities (not a persistent flag);
             typically `true` when the contact has no associated book entries and the
             caller can destroy it.
+        account_code:
+          type: string
+          nullable: true
+          description: Accounting code assigned to this contact (Aplifisa integration field).
 
     ContactResource:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1783,6 +1783,25 @@ components:
         deductible_expense_percent:
           type: number
           description: Deductible expense percentage
+        counterpart_account_code:
+          type: string
+          nullable: true
+          description: Accounting ledger code for the counterpart account on this line item (Aplifisa).
+        isp:
+          type: boolean
+          description: Whether reverse charge (Inversión del Sujeto Pasivo) applies. Placeholder — always false until B0.
+        retention_key:
+          type: string
+          nullable: true
+          description: IRPF retention key code from owner preferences (e.g. "01" for professional activities).
+        model_190_key:
+          type: string
+          nullable: true
+          description: Modelo 190 key for this retention. Placeholder — not yet populated.
+        model_190_subkey:
+          type: string
+          nullable: true
+          description: Modelo 190 subkey for this retention. Placeholder — not yet populated.
 
     ItemWritableAttributes:
       type: object
@@ -2027,6 +2046,82 @@ components:
         recipient_country_code:
           type: string
           nullable: true
+        retention_amount:
+          type: string
+          description: Total retention (IRPF) amount withheld across all items.
+        retention_rates:
+          type: array
+          description: Retention breakdown grouped by rate. Each entry gives the rate percentage and the total amount withheld at that rate.
+          items:
+            type: object
+            properties:
+              rate:
+                type: number
+                description: Retention percentage (e.g. 15.0)
+              amount:
+                type: number
+                description: Total amount withheld at this rate
+        economic_activity_id:
+          type: integer
+          nullable: true
+          description: ID of the economic activity associated with this document (Aplifisa).
+        document_type:
+          type: string
+          nullable: true
+          description: SII fiscal document type (F1/F2 for normal, R1–R5 for credit notes). Placeholder — not yet populated.
+        tax_form:
+          type: string
+          nullable: true
+          description: Tax form reference (e.g. 303, 130). Placeholder — not yet populated.
+        contact_account_code:
+          type: string
+          nullable: true
+          description: Accounting ledger code for the counterpart contact (Aplifisa).
+        vat_breakdown:
+          type: object
+          nullable: true
+          description: VAT breakdown grouped by rate. Keys are rate percentages (e.g. "21"). Each entry contains `tax` (VAT amounts by rate) and `base` (taxable bases by rate).
+          properties:
+            tax:
+              type: object
+              additionalProperties:
+                type: number
+            base:
+              type: object
+              additionalProperties:
+                type: number
+        equalization_tax_amount:
+          type: string
+          nullable: true
+          description: Equalization surcharge amount (recargo de equivalencia).
+        equalization_tax_rate:
+          type: number
+          nullable: true
+          description: Equalization surcharge rate. Placeholder — not yet populated.
+        rectification_type:
+          type: string
+          nullable: true
+          description: Veri*factu rectification type. Placeholder.
+        rectification_kind:
+          type: string
+          nullable: true
+          description: Veri*factu rectification kind. Placeholder.
+        operation_classification:
+          type: string
+          nullable: true
+          description: Veri*factu operation classification. Placeholder.
+        exempt_operation_type:
+          type: string
+          nullable: true
+          description: Veri*factu exempt operation type. Placeholder.
+        regime_key:
+          type: string
+          nullable: true
+          description: Veri*factu regime key. Placeholder.
+        operation_description:
+          type: string
+          nullable: true
+          description: Veri*factu operation description. Placeholder.
 
     BookEntryResource:
       type: object
@@ -2058,8 +2153,6 @@ components:
             total_amount_without_taxes:
               type: string
             vat_amount:
-              type: string
-            retention_amount:
               type: string
             last_sent_at:
               type: string


### PR DESCRIPTION
feat: add Aplifisa integration fields and filters to openapi spec

## Description

Documents the API v1 changes introduced by the Aplifisa integration feature branch.

**New field — Contacts:**
- `account_code` (nullable string) added to `ContactAttributes` — maps to `client_accounting_number`, used by Aplifisa for accounting reconciliation.

**New query filters:**

| Endpoint | `filter[economic_activity_id]` | `filter[economic_activity_epigraph]` | `filter[verifactu_status]` |
|---|---|---|---|
| `GET /book_entries` | ✅ | ✅ | ✅ |
| `GET /invoices` | ✅ | ✅ | ✅ |
| `GET /paysheets` | ✅ | ✅ | ✅ |
| `GET /additional_incomes` | ✅ | ✅ | — |

`filter[verifactu_status]` accepts: `noop`, `draft`, `final`, `sent_aeat`, `approved_aeat`, `approved_with_errors_aeat`, `rejected_aeat`.

Note: `additional_incomes` accepts `filter[economic_activity_id]` but not `filter[verifactu_status]` — the endpoint always returns only `noop` entries regardless.

## Motivation and Context

- [QUI-11439](https://app.clickup.com/t/20457519/QUI-11439)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

-------

# Summary of changes requested on [Aplifisa RFC](https://app.clickup.com/20457519/v/dc/kga1f-4308/kga1f-122612) — API V1 Changes

## New fields on documents (`BookEntry`)

| Field | Notes |
|---|---|
| `economic_activity_id` | ID of the associated economic activity |
| `vat_breakdown` | VAT breakdown per rate; previously gated behind `with_detailed_amounts` flag — now returned by default |
| `equalization_tax_rate`, `equalization_tax_amount` | Same as above |
| `rectification_type` | `S` (substitution) or `I` (difference) — credit notes only |
| `rectification_kind` | `R1`–`R5` — credit notes only |
| `operation_classification` | `S1`, `S2`, `N1`, `N2` |
| `exempt_operation_type` | `E1`–`E6`, or null |
| `regime_key` | VAT regime code (e.g. `01` = general, `08` = cash accounting) |
| `operation_description` | Free-text description matching Verifactu billing record |
| `tax_form` | Tax model code (e.g. `01` = Modelo 303) |
| `contact_account_code` | Contact's accounting account code, direction-aware (income vs expense) |
| `retention_amount` | Total IRPF retention amount withheld across all line items |
| `retention_rates` | IRPF retention breakdown: array of `{ rate, amount }` objects, one per distinct retention percentage |

## New fields on document lines (`BookEntryItem`)

| Field | Notes |
|---|---|
| `counterpart_account_code` | Full accounting account code for the line |
| `isp` | Boolean — reverse charge (Inversión del Sujeto Pasivo) |
| `retention_key` | IRPF withholding code (e.g. `180` = 19% rental) |
| `model_190_key`, `model_190_subkey` | Modelo 190 classification for lines with IRPF retention |

## New field on contacts

| Field | Notes |
|---|---|
| `account_code` | Full accounting account code (prefix + suffix concatenated) |

## New index filters

| Filter | Endpoints |
|---|---|
| `filter[economic_activity_id]` | `/invoices`, `/book_entries`, `/paysheets`, `/additional_incomes` |
| `filter[verifactu_status]` | `/invoices`, `/book_entries`, `/paysheets` |

## Removed endpoint

`GET /tickets` (index + CRUD) was removed in QUI-11224 and is no longer available in V1. PDF download routes (`/tickets/:id/download`) are kept for internal use by the V2 serializer. Aplifisa cannot retrieve this endpoint — no changes needed on this endpoint.

---

## Implementation checklist

- [x] Contact: `account_code`
- [x] Book entry: `economic_activity_id`
- [x] Book entry: `vat_breakdown`
- [x] Book entry: `equalization_tax_rate`
- [x] Book entry: `equalization_tax_amount`
- [x] Book entry: `rectification_type`
- [x] Book entry: `rectification_kind`
- [x] Book entry: `operation_classification`
- [x] Book entry: `exempt_operation_type`
- [x] Book entry: `regime_key`
- [x] Book entry: `operation_description`
- [x] Book entry: `tax_form`
- [x] Book entry: `contact_account_code`
- [x] Book entry: `retention_amount`
- [x] Book entry: `retention_rates`
- [x] Book entry item: `counterpart_account_code`
- [x] Book entry item: `isp`
- [x] Book entry item: `retention_key`
- [x] Book entry item: `model_190_key`
- [x] Book entry item: `model_190_subkey`
- [x] Filter `economic_activity_id` on `/invoices`
- [x] Filter `economic_activity_id` on `/book_entries`
- [x] Filter `economic_activity_id` on `/paysheets`
- [x] Filter `economic_activity_id` on `/additional_incomes`
- [x] Filter `verifactu_status` on `/invoices`
- [x] Filter `verifactu_status` on `/book_entries`
- [x] Filter `verifactu_status` on `/paysheets`

`verifactu_status` is not available on `additional_incomes` — they always have `noop` status.
