### PR TITLE
feat: document economic_activity_id none/any filter, filter x-internal query params

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -455,6 +455,17 @@ paths:
           schema:
             type: string
           description: Search term for field-level query filter
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
         - name: sort
           in: query
           schema:
@@ -532,6 +543,17 @@ paths:
           schema:
             type: string
           description: Search term for field-level query filter
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of invoices
@@ -740,6 +762,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludeSimplifiedInvoice"
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of simplified invoices
@@ -876,6 +909,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludeAdditionalIncome"
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of additional income
@@ -1012,6 +1056,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludePaysheet"
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of paysheets

--- a/scripts/filter-internal.js
+++ b/scripts/filter-internal.js
@@ -1,10 +1,10 @@
-// Splits openapi.yaml (the source of truth, which may contain fields tagged
-// `x-internal: true`) into two artifacts:
+// Splits openapi.yaml (the source of truth, which may contain fields and
+// query parameters tagged `x-internal: true`) into two artifacts:
 //
-//   - a PUBLIC spec with every `x-internal` property removed entirely
-//     (published to GitHub Pages)
-//   - a FULL spec with every field intact, only the `x-internal` marker
-//     stripped (uploaded as a private CI artifact, e.g. for Aplifisa)
+//   - a PUBLIC spec with every `x-internal` property and parameter removed
+//     entirely (published to GitHub Pages)
+//   - a FULL spec with every field/parameter intact, only the `x-internal`
+//     marker stripped (uploaded as a private CI artifact, e.g. for Aplifisa)
 //
 // See ../README.md for the full pipeline and the reasoning behind it.
 
@@ -16,9 +16,12 @@ import yaml from 'js-yaml'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
 
-// Recursively removes any `properties` entry whose schema is tagged
-// `x-internal: true`, and drops its name from a sibling `required` array
-// if present. Mutates and returns `node`.
+// Recursively removes:
+//   - any `properties` entry whose schema is tagged `x-internal: true`
+//     (dropping its name from a sibling `required` array if present)
+//   - any entry in a `parameters` array (path-item or operation level)
+//     that is itself tagged `x-internal: true`
+// Mutates and returns `node`.
 export function removeInternalProperties(node) {
   if (Array.isArray(node)) {
     node.forEach(removeInternalProperties)
@@ -42,6 +45,12 @@ export function removeInternalProperties(node) {
     if (Array.isArray(node.required) && removedKeys.length > 0) {
       node.required = node.required.filter((key) => !removedKeys.includes(key))
     }
+  }
+
+  if (Array.isArray(node.parameters)) {
+    node.parameters = node.parameters.filter(
+      (param) => !(param && typeof param === 'object' && param['x-internal'] === true)
+    )
   }
 
   for (const value of Object.values(node)) {

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -249,7 +249,7 @@ test('the real openapi.yaml: every x-internal field disappears from the filtered
 })
 
 // Finds every (path, method, paramName) tuple tagged x-internal directly under
-// paths.*.*.parameters in the ORIGINAL doc.
+// paths.*.<http_method>.parameters in the ORIGINAL doc.
 function findTaggedParameters(sourceDoc) {
   const tuples = []
   for (const [pathKey, pathItem] of Object.entries(sourceDoc.paths || {})) {

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -22,6 +22,37 @@ test('removeInternalProperties drops only x-internal properties', () => {
   assert.deepEqual(Object.keys(doc.properties), ['public_field'])
 })
 
+test('removeInternalProperties drops only x-internal entries from a parameters array', () => {
+  const doc = {
+    get: {
+      parameters: [
+        { name: 'public_filter', in: 'query', schema: { type: 'string' } },
+        { name: 'secret_filter', in: 'query', 'x-internal': true, schema: { type: 'string' } }
+      ]
+    }
+  }
+
+  removeInternalProperties(doc)
+
+  assert.deepEqual(doc.get.parameters.map((p) => p.name), ['public_filter'])
+})
+
+test('removeInternalProperties leaves a parameters array with no internal entries unchanged', () => {
+  const doc = {
+    get: {
+      parameters: [
+        { name: 'a', in: 'query', schema: { type: 'string' } },
+        { name: 'b', in: 'query', schema: { type: 'string' } }
+      ]
+    }
+  }
+  const before = structuredClone(doc)
+
+  removeInternalProperties(doc)
+
+  assert.deepEqual(doc, before)
+})
+
 test('removeInternalProperties cleans up the required array', () => {
   const doc = {
     type: 'object',
@@ -135,6 +166,38 @@ test('buildSpecs: filtered spec has no x-internal fields and no "x-internal" str
   assert.equal(JSON.stringify(full).includes('x-internal'), false)
 })
 
+test('buildSpecs: filtered spec drops x-internal query parameters, full spec keeps them marker-stripped', () => {
+  const source = yaml.dump({
+    paths: {
+      '/things': {
+        get: {
+          parameters: [
+            { name: 'filter[open]', in: 'query', schema: { type: 'string' }, description: 'visible to everyone' },
+            {
+              name: 'filter[hidden]',
+              in: 'query',
+              'x-internal': true,
+              schema: { type: 'string' },
+              description: 'Vendor integration only.'
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  const { filtered, full } = buildSpecs(source)
+
+  const filteredParams = filtered.paths['/things'].get.parameters
+  assert.deepEqual(filteredParams.map((p) => p.name), ['filter[open]'])
+  assert.equal(JSON.stringify(filtered).includes('x-internal'), false)
+
+  // full keeps both parameters, marker stripped
+  const fullParams = full.paths['/things'].get.parameters
+  assert.deepEqual(fullParams.map((p) => p.name).sort(), ['filter[hidden]', 'filter[open]'])
+  assert.equal(JSON.stringify(full).includes('x-internal'), false)
+})
+
 // Finds every (schemaName, propertyName) pair tagged x-internal directly under
 // components.schemas.*.properties in the ORIGINAL doc (field names can repeat
 // across unrelated schemas, e.g. "document_type" exists on both ContactAttributes
@@ -183,6 +246,42 @@ test('the real openapi.yaml: every x-internal field disappears from the filtered
     Object.keys(filtered.components.schemas.AccountingCategoryAttributes.properties).includes('accounting_digits_number'),
     true
   )
+})
+
+// Finds every (path, method, paramName) tuple tagged x-internal directly under
+// paths.*.*.parameters in the ORIGINAL doc.
+function findTaggedParameters(sourceDoc) {
+  const tuples = []
+  for (const [pathKey, pathItem] of Object.entries(sourceDoc.paths || {})) {
+    for (const [method, operation] of Object.entries(pathItem || {})) {
+      if (!Array.isArray(operation?.parameters)) continue
+      for (const param of operation.parameters) {
+        if (param && param['x-internal'] === true) {
+          tuples.push({ pathKey, method, paramName: param.name })
+        }
+      }
+    }
+  }
+  return tuples
+}
+
+test('the real openapi.yaml: every x-internal query parameter disappears from the filtered spec, survives in the full spec', () => {
+  const sourcePath = path.join(__dirname, '..', 'openapi.yaml')
+  const sourceYaml = fs.readFileSync(sourcePath, 'utf8')
+  const sourceDoc = yaml.load(sourceYaml)
+
+  const tagged = findTaggedParameters(sourceDoc)
+  assert.ok(tagged.length > 0, 'expected at least one x-internal query parameter in openapi.yaml')
+
+  const { filtered, full } = buildSpecs(sourceYaml)
+
+  for (const { pathKey, method, paramName } of tagged) {
+    const filteredNames = filtered.paths[pathKey][method].parameters.map((p) => p.name)
+    const fullNames = full.paths[pathKey][method].parameters.map((p) => p.name)
+
+    assert.equal(filteredNames.includes(paramName), false, `${method} ${pathKey} ${paramName} leaked into the public spec`)
+    assert.ok(fullNames.includes(paramName), `${method} ${pathKey} ${paramName} missing from the full spec`)
+  }
 })
 
 test('the real openapi.yaml: no "Aplifisa" mention survives in the public spec', () => {


### PR DESCRIPTION
### Description
Documents the `none`/`any` sentinel values added to `filter[economic_activity_id]` in quipuapp#11708, across the 5 real public v1 endpoints that support it (`book_entries`, `invoices`, `paysheets`, `additional_incomes`, `simplified_invoices`). Tagged `x-internal` since the underlying field is Aplifisa-only.

Also fixes a gap in `filter-internal.js`: it only ever stripped `x-internal` schema *properties* before publishing — an `x-internal` query *parameter* would have leaked into the public spec unfiltered. `removeInternalProperties` now also filters `parameters` arrays, with new test coverage for both the unit-level behavior and the real `openapi.yaml`.

Note: quipuapp#11708's description also mentions `tickets` and `liquidations`, but neither actually applies — `tickets` CRUD was removed from v1 (QUI-11224, only PDF download routes remain), and `liquidations` isn't touched by that PR's diff at all (it lives on an unmerged branch). Nothing to document for either.

### Motivation and Context
- [QUI-11878](https://app.clickup.com/t/20457519/QUI-11878)
- [Backend](https://github.com/quipuapp/quipuapp/pull/11708)

### Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes