### PR TITLE
docs: close api v1 public-doc gaps, add path/schema x-internal filtering [QUI-11904]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ npm run build   # writes the filtered openapi.yaml + dist-internal/openapi.json 
 npm run lint:spec  # quick YAML-validity check
 ```
 
+### What each filter step does (`scripts/filter-internal.js`)
+
+`buildSpecs` runs these in order to produce the filtered (public) spec; the full (internal) spec only
+runs `applyInternalDescriptions` + `stripInternalMarkers`:
+
+- **`removeInternalPaths`** — drops a whole `paths` entry tagged `x-internal: true` on the path item,
+  or an individual operation (`get`/`post`/...) tagged `x-internal: true` when the path item itself
+  isn't fully internal.
+- **`removeInternalComponents`** — drops whole `components.schemas` / `parameters` / `responses` /
+  `requestBodies` entries tagged `x-internal: true` on the definition itself (used for resources that
+  are entirely internal, e.g. `LiquidationResource`, as opposed to one internal field on an otherwise
+  public resource).
+- **`removeInternalTags`** — drops top-level `tags` registry entries (used for docs-UI grouping) tagged
+  `x-internal: true`.
+- **`removeInternalProperties`** — drops any `properties` entry whose schema is tagged
+  `x-internal: true` (and removes its name from a sibling `required` array), plus any `parameters`
+  array entry tagged the same way. Recurses through `allOf`/`items`/`additionalProperties` too, so a
+  property nested inside a composed schema is still caught.
+- **`removeDanglingRefs`** — cleanup pass that must run *after* `removeInternalComponents`. If a
+  `oneOf`/`anyOf` list elsewhere in the doc (e.g. a polymorphic `included` items schema) still `$ref`s
+  a schema that step just deleted, the public spec would ship a dangling reference. This filters those
+  entries out, keeping every other `$ref` untouched.
+- **`applyInternalDescriptions`** (full spec only) — where a field carries both a public-safe
+  `description` and a fuller `x-internal-description` (shared fields whose *allowed-values list*
+  includes an internal-only value, not droppable wholesale), swaps `description` for the complete
+  text. The filtered spec never calls this — it already has the safe text in `description`.
+- **`stripInternalMarkers`** — recursively deletes the `x-internal` / `x-internal-description` marker
+  keys themselves, leaving the field they were attached to untouched. Run last on both specs so no
+  marker ever leaks into either output.
+
 ## Future improvements
 
 - Auto-generate `openapi.yaml` from request specs using `rspec-openapi`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -751,6 +751,7 @@ paths:
                         - $ref: "#/components/schemas/ContactResource"
                         - $ref: "#/components/schemas/AccountingCategoryResource"
                         - $ref: "#/components/schemas/AccountingSubcategoryResource"
+                        - $ref: "#/components/schemas/LiquidationResource"
               examples:
                 bare:
                   summary: Without sideloading
@@ -1287,6 +1288,15 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AdditionalIncomeResource"
+                  included:
+                    type: array
+                    description: Populated when `?include=` is used. Contains sideloaded resources.
+                    items:
+                      oneOf:
+                        - $ref: "#/components/schemas/ItemResource"
+                        - $ref: "#/components/schemas/AccountingCategoryResource"
+                        - $ref: "#/components/schemas/AccountingSubcategoryResource"
+                        - $ref: "#/components/schemas/LiquidationResource"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1553,6 +1563,15 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/PaysheetResource"
+                  included:
+                    type: array
+                    description: Populated when `?include=` is used. Contains sideloaded resources.
+                    items:
+                      oneOf:
+                        - $ref: "#/components/schemas/ContactResource"
+                        - $ref: "#/components/schemas/AccountingCategoryResource"
+                        - $ref: "#/components/schemas/AccountingSubcategoryResource"
+                        - $ref: "#/components/schemas/LiquidationResource"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3323,6 +3342,11 @@ components:
               $ref: "#/components/schemas/RelationshipLinkageArray"
             amended_invoice:
               $ref: "#/components/schemas/RelationshipLinkage"
+            liquidations:
+              x-internal: true
+              allOf:
+                - $ref: "#/components/schemas/RelationshipLinkageArray"
+              description: Money entries/book entries reconciled against this invoice. (Aplifisa integration only.)
 
     InvoiceWritable:
       type: object
@@ -3639,6 +3663,11 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            liquidations:
+              x-internal: true
+              allOf:
+                - $ref: "#/components/schemas/RelationshipLinkageArray"
+              description: Money entries/book entries reconciled against this additional income. (Aplifisa integration only.)
 
     AdditionalIncomeWritable:
       type: object
@@ -3775,6 +3804,11 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            liquidations:
+              x-internal: true
+              allOf:
+                - $ref: "#/components/schemas/RelationshipLinkageArray"
+              description: Money entries/book entries reconciled against this paysheet. (Aplifisa integration only.)
 
     PaysheetWritable:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3341,6 +3341,18 @@ components:
                 present. For outbound invoices, sets the invoice's internal number directly
                 (overriding `number` if both are sent). For inbound invoices, sets the internal
                 number while `number` is stored as the supplier's external reference.
+            filing_number:
+              type: string
+              nullable: true
+              description: >
+                Legacy per-numeration-series ordinal (a positive integer, sent as a string).
+                Only meaningful together with an explicit numeration series: the final `number`
+                is then derived from the series prefix plus this ordinal. A non-integer value
+                is treated the same as `number`. Distinct from `complete_number`, which replaces
+                `number` itself rather than this series-ordinal role. Kept for backward
+                compatibility with historical/manually-numbered entries; prefer `number` /
+                `complete_number` otherwise. Only accepted on creation — ignored if sent on an
+                update.
             due_dates:
               type: array
               items:
@@ -3506,6 +3518,18 @@ components:
               description: >
                 Full simplified invoice number including prefix, authoritative when present
                 (overrides `number` if both are sent).
+            filing_number:
+              type: string
+              nullable: true
+              description: >
+                Legacy per-numeration-series ordinal (a positive integer, sent as a string).
+                Only meaningful together with an explicit numeration series: the final `number`
+                is then derived from the series prefix plus this ordinal. A non-integer value
+                is treated the same as `number`. Distinct from `complete_number`, which replaces
+                `number` itself rather than this series-ordinal role. Kept for backward
+                compatibility with historical/manually-numbered entries; prefer `number` /
+                `complete_number` otherwise. Only accepted on creation — ignored if sent on an
+                update.
             due_dates:
               type: array
               items:
@@ -3628,6 +3652,18 @@ components:
               description: >
                 Full additional income number including prefix, authoritative when present
                 (overrides `number` if both are sent).
+            filing_number:
+              type: string
+              nullable: true
+              description: >
+                Legacy per-numeration-series ordinal (a positive integer, sent as a string).
+                Only meaningful together with an explicit numeration series: the final `number`
+                is then derived from the series prefix plus this ordinal. A non-integer value
+                is treated the same as `number`. Distinct from `complete_number`, which replaces
+                `number` itself rather than this series-ordinal role. Kept for backward
+                compatibility with historical/manually-numbered entries; prefer `number` /
+                `complete_number` otherwise. Only accepted on creation — ignored if sent on an
+                update.
             due_dates:
               type: array
               items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2489,6 +2489,11 @@ components:
       description: |
         Comma-separated list of related resources to embed in the `included`
         array (JSON:API sideloading). Allowed values: `items`, `contact`,
+        `accounting_category`, `accounting_subcategory`.
+        Example: `?include=items,contact`.
+      x-internal-description: |
+        Comma-separated list of related resources to embed in the `included`
+        array (JSON:API sideloading). Allowed values: `items`, `contact`,
         `accounting_category`, `accounting_subcategory`, `liquidations`.
         Example: `?include=items,contact`.
     IncludeSimplifiedInvoice:
@@ -2497,6 +2502,10 @@ components:
       schema:
         type: string
       description: |
+        Comma-separated list of related resources to embed in the `included`
+        array. Allowed values: `items`, `accounting_category`,
+        `accounting_subcategory`, `attachments`. Example: `?include=items`.
+      x-internal-description: |
         Comma-separated list of related resources to embed in the `included`
         array. Allowed values: `items`, `accounting_category`,
         `accounting_subcategory`, `attachments`, `liquidations`. Example: `?include=items`.
@@ -2508,6 +2517,10 @@ components:
       description: |
         Comma-separated list of related resources to embed in the `included`
         array. Allowed values: `items`, `accounting_category`,
+        `accounting_subcategory`, `attachments`. Example: `?include=items`.
+      x-internal-description: |
+        Comma-separated list of related resources to embed in the `included`
+        array. Allowed values: `items`, `accounting_category`,
         `accounting_subcategory`, `attachments`, `liquidations`. Example: `?include=items`.
     IncludePaysheet:
       name: include
@@ -2515,6 +2528,11 @@ components:
       schema:
         type: string
       description: |
+        Comma-separated list of related resources to embed in the `included`
+        array. Allowed values: `contact`, `accounting_category`,
+        `accounting_subcategory`, `attachments`.
+        Example: `?include=contact,accounting_subcategory`.
+      x-internal-description: |
         Comma-separated list of related resources to embed in the `included`
         array. Allowed values: `contact`, `accounting_category`,
         `accounting_subcategory`, `attachments`, `liquidations`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4062,6 +4062,13 @@ components:
             book_entry_id:
               type: integer
               nullable: true
+            kind:
+              type: string
+              enum: [charge, payment]
+              description: >
+                Money movement direction: "charge" (cobro) or "payment" (pago). Based on the
+                money entry's amount sign when present, otherwise on the settled document's
+                direction — the same convention used by the A3/Sage accounting exports.
             date:
               type: string
               format: date

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,7 +72,7 @@ tags:
   - name: Contacts
     description: Clients and suppliers
   - name: Book Entries
-    description: "Read-only listing of all book entries. The type filter accepts: invoices, paysheets, tickets."
+    description: "Read-only listing of all book entries. The type filter accepts: invoices, paysheets, tickets, additional_incomes."
   - name: Invoices
     description: Full invoices (income and expenses)
   - name: Simplified Invoices
@@ -89,6 +89,15 @@ tags:
     description: Accounting subcategories
   - name: Attachments
     description: File attachments for book entries
+  - name: Liquidations
+    x-internal: true
+    description: "Read-only. Only available for owners with a supported accounting-software integration enabled (Aplifisa integration only.)"
+  - name: Money Accounts
+    x-internal: true
+    description: "Read-only. Only available for owners with a supported accounting-software integration enabled (Aplifisa integration only.)"
+  - name: Money Entries
+    x-internal: true
+    description: "Read-only. Only available for owners with a supported accounting-software integration enabled (Aplifisa integration only.)"
 
 paths:
   # ── Authentication ───────────────────────────────────────────────────────
@@ -214,10 +223,16 @@ paths:
                     locale: es
                     sign_up_draft_data: null
                     is_full_admin: false
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Contacts ───────────────────────────────────────────────────────────
   /{owner_slug}/contacts:
@@ -276,8 +291,14 @@ paths:
                       $ref: "#/components/schemas/ContactResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createContact
       summary: Create contact
@@ -314,10 +335,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/ContactResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/contacts/{id}:
     get:
@@ -338,10 +365,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/ContactResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updateContact
       summary: Update contact
@@ -371,12 +404,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/ContactResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteContact
       summary: Delete contact
@@ -388,10 +427,16 @@ paths:
       responses:
         "204":
           description: Contact deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Book Entries (read-only) ───────────────────────────────────────────
   /{owner_slug}/book_entries:
@@ -407,11 +452,19 @@ paths:
         - $ref: "#/components/parameters/AcceptHeader"
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/IncludeBookEntry"
+        - name: with_detailed_amounts
+          in: query
+          schema:
+            type: boolean
+          description: >
+            Include the `detailed_amounts` breakdown object in each entry. Presence of the
+            parameter is enough — any value (including empty) enables it.
         - name: filter[type]
           in: query
           schema:
             type: string
-            enum: [invoices, tickets, paysheets]
+            enum: [invoices, tickets, paysheets, additional_incomes]
           description: Filter by entry type
         - name: filter[kind]
           in: query
@@ -466,6 +519,16 @@ paths:
             entries with some economic activity assigned). Any other non-numeric value returns
             an empty result rather than an error.
             (Aplifisa integration only.)
+        - name: filter[economic_activity_epigraph]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) code, e.g. `399`. Matches entries whose
+            assigned economic activity has this epigraph, scoped to the owner's own economic
+            activities.
+            (Aplifisa integration only.)
         - name: sort
           in: query
           schema:
@@ -486,8 +549,14 @@ paths:
                       $ref: "#/components/schemas/BookEntryResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Invoices ───────────────────────────────────────────────────────────
   /{owner_slug}/invoices:
@@ -554,6 +623,16 @@ paths:
             entries with some economic activity assigned). Any other non-numeric value returns
             an empty result rather than an error.
             (Aplifisa integration only.)
+        - name: filter[economic_activity_epigraph]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) code, e.g. `399`. Matches entries whose
+            assigned economic activity has this epigraph, scoped to the owner's own economic
+            activities.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of invoices
@@ -568,8 +647,14 @@ paths:
                       $ref: "#/components/schemas/InvoiceResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createInvoice
       summary: Create invoice
@@ -626,10 +711,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/InvoiceResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/invoices/{id}:
     get:
@@ -695,10 +786,16 @@ paths:
                           unitary_amount: "1500.00"
                           quantity: 1
                           vat_percent: 21.0
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updateInvoice
       summary: Update invoice
@@ -728,12 +825,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/InvoiceResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteInvoice
       summary: Delete invoice
@@ -745,10 +848,79 @@ paths:
       responses:
         "204":
           description: Invoice deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/invoices/{id}/download:
+    get:
+      operationId: downloadInvoicePdf
+      summary: Download invoice PDF
+      description: Returns the (outbound) invoice rendered as a PDF file.
+      tags: [Invoices]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: PDF file
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/invoices/{id}/ephemeral_open_download:
+    get:
+      operationId: ephemeralOpenDownloadInvoicePdf
+      summary: Download invoice PDF via ephemeral open token
+      description: >
+        Returns the invoice rendered as a PDF file using a short-lived, token-authenticated
+        link instead of a Bearer token (see `ephemeral_open_download_pdf_url` on the invoice
+        resource). Does not require authentication.
+      tags: [Invoices]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/ResourceId"
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Ephemeral open-download token issued alongside the document.
+      responses:
+        "200":
+          description: PDF file
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Document not found, or the token is missing, invalid, or expired
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Simplified Invoices ────────────────────────────────────────────────
   /{owner_slug}/simplified_invoices:
@@ -773,6 +945,16 @@ paths:
             entries with some economic activity assigned). Any other non-numeric value returns
             an empty result rather than an error.
             (Aplifisa integration only.)
+        - name: filter[economic_activity_epigraph]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) code, e.g. `399`. Matches entries whose
+            assigned economic activity has this epigraph, scoped to the owner's own economic
+            activities.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of simplified invoices
@@ -787,8 +969,14 @@ paths:
                       $ref: "#/components/schemas/SimplifiedInvoiceResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createSimplifiedInvoice
       summary: Create simplified invoice
@@ -817,10 +1005,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/SimplifiedInvoiceResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/simplified_invoices/{id}:
     get:
@@ -842,10 +1036,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/SimplifiedInvoiceResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updateSimplifiedInvoice
       summary: Update simplified invoice
@@ -875,12 +1075,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/SimplifiedInvoiceResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteSimplifiedInvoice
       summary: Delete simplified invoice
@@ -892,10 +1098,80 @@ paths:
       responses:
         "204":
           description: Simplified invoice deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/simplified_invoices/{id}/download:
+    get:
+      operationId: downloadSimplifiedInvoicePdf
+      summary: Download simplified invoice PDF
+      description: Returns the simplified invoice rendered as a PDF file.
+      tags: [Simplified Invoices]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: PDF file
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/simplified_invoices/{id}/ephemeral_open_download:
+    get:
+      operationId: ephemeralOpenDownloadSimplifiedInvoicePdf
+      summary: Download simplified invoice PDF via ephemeral open token
+      description: >
+        Returns the simplified invoice rendered as a PDF file using a short-lived,
+        token-authenticated link instead of a Bearer token (see
+        `ephemeral_open_download_pdf_url` on the simplified invoice resource). Does not
+        require authentication.
+      tags: [Simplified Invoices]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/ResourceId"
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Ephemeral open-download token issued alongside the document.
+      responses:
+        "200":
+          description: PDF file
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Document not found, or the token is missing, invalid, or expired
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Additional Incomes ─────────────────────────────────────────────────
   /{owner_slug}/additional_incomes:
@@ -920,6 +1196,16 @@ paths:
             entries with some economic activity assigned). Any other non-numeric value returns
             an empty result rather than an error.
             (Aplifisa integration only.)
+        - name: filter[economic_activity_epigraph]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) code, e.g. `399`. Matches entries whose
+            assigned economic activity has this epigraph, scoped to the owner's own economic
+            activities.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of additional income
@@ -934,8 +1220,14 @@ paths:
                       $ref: "#/components/schemas/AdditionalIncomeResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createAdditionalIncome
       summary: Create additional income
@@ -964,10 +1256,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AdditionalIncomeResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/additional_incomes/{id}:
     get:
@@ -989,10 +1287,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AdditionalIncomeResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updateAdditionalIncome
       summary: Update additional income
@@ -1022,12 +1326,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AdditionalIncomeResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteAdditionalIncome
       summary: Delete additional income
@@ -1039,10 +1349,80 @@ paths:
       responses:
         "204":
           description: Additional income deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/additional_incomes/{id}/download:
+    get:
+      operationId: downloadAdditionalIncomePdf
+      summary: Download additional income PDF
+      description: >
+        Additional incomes never generate or expose a PDF, so this always returns `404`.
+        The route exists for parity with the other book entry types.
+      tags: [Additional Incomes]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: PDF file
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/additional_incomes/{id}/ephemeral_open_download:
+    get:
+      operationId: ephemeralOpenDownloadAdditionalIncomePdf
+      summary: Download additional income PDF via ephemeral open token
+      description: >
+        Additional incomes never generate or expose a PDF, so this always returns `404`.
+        The route exists for parity with the other book entry types.
+      tags: [Additional Incomes]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/ResourceId"
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Ephemeral open-download token issued alongside the document.
+      responses:
+        "200":
+          description: PDF file
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Always returned — additional incomes never generate a PDF
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Paysheets ──────────────────────────────────────────────────────────
   /{owner_slug}/paysheets:
@@ -1067,6 +1447,16 @@ paths:
             entries with some economic activity assigned). Any other non-numeric value returns
             an empty result rather than an error.
             (Aplifisa integration only.)
+        - name: filter[economic_activity_epigraph]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) code, e.g. `399`. Matches entries whose
+            assigned economic activity has this epigraph, scoped to the owner's own economic
+            activities.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of paysheets
@@ -1081,8 +1471,14 @@ paths:
                       $ref: "#/components/schemas/PaysheetResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createPaysheet
       summary: Create paysheet
@@ -1126,10 +1522,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/PaysheetResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/paysheets/{id}:
     get:
@@ -1151,10 +1553,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/PaysheetResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updatePaysheet
       summary: Update paysheet
@@ -1184,12 +1592,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/PaysheetResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deletePaysheet
       summary: Delete paysheet
@@ -1201,10 +1615,16 @@ paths:
       responses:
         "204":
           description: Paysheet deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Numbering Series ──────────────────────────────────────────────────
   /{owner_slug}/numbering_series:
@@ -1253,8 +1673,14 @@ paths:
                       $ref: "#/components/schemas/NumberingSeriesResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createNumberingSeries
       summary: Create numbering series
@@ -1292,10 +1718,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/NumberingSeriesResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/numbering_series/{id}:
     get:
@@ -1316,10 +1748,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/NumberingSeriesResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updateNumberingSeries
       summary: Update numbering series
@@ -1350,12 +1788,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/NumberingSeriesResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteNumberingSeries
       summary: Delete numbering series
@@ -1367,10 +1811,16 @@ paths:
       responses:
         "204":
           description: Numbering series deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Accounting Categories (read-only) ─────────────────────────────────
   /{owner_slug}/accounting_categories:
@@ -1383,6 +1833,11 @@ paths:
         - $ref: "#/components/parameters/AcceptHeader"
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
+        - name: filter[id]
+          in: query
+          schema:
+            type: string
+          description: Filter by ID (comma-separated for multiple)
         - name: filter[kind]
           in: query
           schema:
@@ -1414,8 +1869,14 @@ paths:
                       $ref: "#/components/schemas/AccountingCategoryResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/accounting_categories/{id}:
     get:
@@ -1436,10 +1897,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AccountingCategoryResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Accounting Subcategories ──────────────────────────────────────────
   /{owner_slug}/accounting_subcategories:
@@ -1471,8 +1938,14 @@ paths:
                       $ref: "#/components/schemas/AccountingSubcategoryResource"
                   meta:
                     $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     post:
       operationId: createAccountingSubcategory
       summary: Create accounting subcategory
@@ -1512,10 +1985,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AccountingSubcategoryResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/accounting_subcategories/{id}:
     get:
@@ -1536,10 +2015,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AccountingSubcategoryResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     patch:
       operationId: updateAccountingSubcategory
       summary: Update accounting subcategory
@@ -1558,7 +2043,7 @@ paths:
               required: [data]
               properties:
                 data:
-                  $ref: "#/components/schemas/AccountingSubcategoryWritable"
+                  $ref: "#/components/schemas/AccountingSubcategoryUpdateWritable"
       responses:
         "200":
           description: Accounting subcategory updated
@@ -1569,12 +2054,18 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AccountingSubcategoryResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteAccountingSubcategory
       summary: Delete accounting subcategory
@@ -1586,10 +2077,16 @@ paths:
       responses:
         "204":
           description: Accounting subcategory deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   # ── Attachments ────────────────────────────────────────────────────────
   /{owner_slug}/attachments:
@@ -1626,10 +2123,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AttachmentResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
   /{owner_slug}/attachments/{id}:
     get:
@@ -1650,10 +2153,16 @@ paths:
                 properties:
                   data:
                     $ref: "#/components/schemas/AttachmentResource"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
     delete:
       operationId: deleteAttachment
       summary: Delete attachment
@@ -1665,10 +2174,234 @@ paths:
       responses:
         "204":
           description: Attachment deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  # ── Liquidations (internal — Aplifisa integration only) ─────────────────
+  /{owner_slug}/liquidations:
+    x-internal: true
+    get:
+      operationId: listLiquidations
+      summary: List liquidations
+      description: >
+        Read-only. Only available for owners with a supported accounting-software integration
+        enabled — returns 403 otherwise. (Aplifisa integration only.)
+      tags: [Liquidations]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Paginated list of liquidations
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LiquidationResource"
+                  meta:
+                    $ref: "#/components/schemas/PaginationMeta"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/liquidations/{id}:
+    x-internal: true
+    get:
+      operationId: getLiquidation
+      summary: Show liquidation
+      description: >
+        Read-only. Only available for owners with a supported accounting-software integration
+        enabled — returns 403 otherwise. (Aplifisa integration only.)
+      tags: [Liquidations]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Liquidation found
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/LiquidationResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  # ── Money Accounts (internal — Aplifisa integration only) ────────────────
+  /{owner_slug}/money_accounts:
+    x-internal: true
+    get:
+      operationId: listMoneyAccounts
+      summary: List money accounts
+      description: >
+        Read-only. Only available for owners with a supported accounting-software integration
+        enabled — returns 403 otherwise. (Aplifisa integration only.)
+      tags: [Money Accounts]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          description: Paginated list of money accounts
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MoneyAccountResource"
+                  meta:
+                    $ref: "#/components/schemas/PaginationMeta"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/money_accounts/{id}:
+    x-internal: true
+    get:
+      operationId: getMoneyAccount
+      summary: Show money account
+      description: >
+        Read-only. Only available for owners with a supported accounting-software integration
+        enabled — returns 403 otherwise. (Aplifisa integration only.)
+      tags: [Money Accounts]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Money account found
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/MoneyAccountResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  # ── Money Entries (internal — Aplifisa integration only) ─────────────────
+  /{owner_slug}/money_entries:
+    x-internal: true
+    get:
+      operationId: listMoneyEntries
+      summary: List money entries
+      description: >
+        Read-only. Only available for owners with a supported accounting-software integration
+        enabled — returns 403 otherwise. (Aplifisa integration only.)
+      tags: [Money Entries]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/PageNumber"
+        - $ref: "#/components/parameters/PageSize"
+        - name: filter[date][from]
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Filter entries with transaction_date on or after this date
+        - name: filter[date][to]
+          in: query
+          schema:
+            type: string
+            format: date
+          description: Filter entries with transaction_date on or before this date
+      responses:
+        "200":
+          description: Paginated list of money entries
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MoneyEntryResource"
+                  meta:
+                    $ref: "#/components/schemas/PaginationMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/money_entries/{id}:
+    x-internal: true
+    get:
+      operationId: getMoneyEntry
+      summary: Show money entry
+      description: >
+        Read-only. Only available for owners with a supported accounting-software integration
+        enabled — returns 403 otherwise. (Aplifisa integration only.)
+      tags: [Money Entries]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Money entry found
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/MoneyEntryResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
 
 # ═════════════════════════════════════════════════════════════════════════
 # Components
@@ -1738,6 +2471,16 @@ components:
         maximum: 100
         default: 25
       description: Number of results per page
+    IncludeBookEntry:
+      name: include
+      in: query
+      schema:
+        type: string
+      description: |
+        Comma-separated list of related resources to embed in the `included`
+        array (JSON:API sideloading). Allowed values: `items`, `contact`,
+        `accounting_category`, `accounting_subcategory`.
+        Example: `?include=items,contact`.
     IncludeInvoice:
       name: include
       in: query
@@ -1755,8 +2498,8 @@ components:
         type: string
       description: |
         Comma-separated list of related resources to embed in the `included`
-        array. Allowed values: `items`, `contact`, `accounting_category`,
-        `accounting_subcategory`, `liquidations`. Example: `?include=items`.
+        array. Allowed values: `items`, `accounting_category`,
+        `accounting_subcategory`, `attachments`, `liquidations`. Example: `?include=items`.
     IncludeAdditionalIncome:
       name: include
       in: query
@@ -1764,8 +2507,8 @@ components:
         type: string
       description: |
         Comma-separated list of related resources to embed in the `included`
-        array. Allowed values: `items`, `contact`, `accounting_category`,
-        `accounting_subcategory`, `liquidations`. Example: `?include=items`.
+        array. Allowed values: `items`, `accounting_category`,
+        `accounting_subcategory`, `attachments`, `liquidations`. Example: `?include=items`.
     IncludePaysheet:
       name: include
       in: query
@@ -2035,6 +2778,9 @@ components:
               nullable: true
             is_full_admin:
               type: boolean
+            accepted_commercial_communication:
+              type: boolean
+              description: Whether the user has opted in to receive commercial communications.
 
     # ── Contacts ─────────────────────────────────────────────────────────
     ContactAttributes:
@@ -2161,6 +2907,42 @@ components:
               type: string
             document_type:
               type: string
+            pdf_language:
+              type: string
+              description: Language used when rendering PDF documents for this contact.
+            incomes_due_date:
+              type: string
+              description: Default due-date preference applied to income documents issued to this contact.
+            incomes_payment_method:
+              type: string
+              description: Default payment method applied to income documents issued to this contact.
+            equivalence_subcharge:
+              type: boolean
+              description: Whether equivalence surcharge applies by default for this contact.
+            expenses_payment_method:
+              type: string
+              description: Default payment method applied to expense documents received from this contact.
+            expenses_due_date:
+              type: string
+              description: Default due-date preference applied to expense documents received from this contact.
+            contact_analytic_value_ids:
+              type: string
+              description: Comma-separated list of analytic value IDs to associate with the contact (e.g. "12,34").
+        relationships:
+          type: object
+          properties:
+            expense_category:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting category applied to expense documents for this contact.
+            expense_subcategory:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting subcategory applied to expense documents for this contact.
+            income_category:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting category applied to income documents for this contact.
+            income_subcategory:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting subcategory applied to income documents for this contact.
 
     # ── Book Entries (read-only) ─────────────────────────────────────────
     BookEntryAttributes:
@@ -2385,6 +3167,53 @@ components:
               amount:
                 type: number
                 description: Total amount withheld at this rate across the document's items.
+        detailed_amounts:
+          type: object
+          description: >
+            Breakdown of the document's totals into accounting/tax components. Only present
+            when the `with_detailed_amounts` query parameter is sent (any value, including
+            empty, enables it).
+          properties:
+            user_amount_without_taxes:
+              type: string
+            user_vat_amount:
+              type: string
+            user_equalization_tax_amount:
+              type: string
+            user_income_tax_amount:
+              type: string
+            user_total_amount:
+              type: string
+            expense_amount:
+              type: string
+            non_deductible_expense_amount:
+              type: string
+            income_amount:
+              type: string
+            input_vat_amount:
+              type: string
+            non_deductible_input_vat_amount:
+              type: string
+            non_deductible_assets_vat_amount:
+              type: string
+            non_computable_input_vat_amount:
+              type: string
+            output_vat_amount:
+              type: string
+            input_equalization_tax_amount:
+              type: string
+            output_equalization_tax_amount:
+              type: string
+            income_tax_withheld_amount:
+              type: string
+            income_tax_deducted_amount:
+              type: string
+            assets_amount:
+              type: string
+            non_deductible_assets_amount:
+              type: string
+            disbursements_amount:
+              type: string
 
     BookEntryResource:
       type: object
@@ -2399,6 +3228,10 @@ components:
         relationships:
           type: object
           properties:
+            items:
+              $ref: "#/components/schemas/RelationshipLinkageArray"
+            contact:
+              $ref: "#/components/schemas/RelationshipLinkage"
             accounting_category:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
@@ -2429,6 +3262,13 @@ components:
             stage:
               type: string
               enum: [draft, final]
+            concepts:
+              type: array
+              items:
+                type: string
+              description: >
+                Distinct line item concepts on this invoice, in item order. Derived from the
+                invoice's items and kept in sync automatically — not directly writable.
             download_pdf_url:
               type: string
               format: uri
@@ -2488,11 +3328,19 @@ components:
             number:
               type: string
               nullable: true
-              description: Full invoice number including prefix (e.g. "INV-2024-001"). Mutually exclusive with `filing_number` when a numeration series is provided.
-            filing_number:
+              description: >
+                Invoice number. For outbound (income) invoices this is the internal filing
+                number/reference; for inbound (expense) invoices this is the supplier's own
+                external reference. `complete_number` takes priority over `number` when both
+                are sent.
+            complete_number:
               type: string
               nullable: true
-              description: Numeric filing number within the assigned series.
+              description: >
+                Full invoice number including prefix (e.g. "INV-2024-001"), authoritative when
+                present. For outbound invoices, sets the invoice's internal number directly
+                (overriding `number` if both are sent). For inbound invoices, sets the internal
+                number while `number` is stored as the supplier's external reference.
             due_dates:
               type: array
               items:
@@ -2547,6 +3395,20 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            attachments:
+              $ref: "#/components/schemas/RelationshipLinkageArray"
+            project:
+              $ref: "#/components/schemas/RelationshipLinkage"
+            book_entry_draft:
+              $ref: "#/components/schemas/RelationshipLinkage"
+            economic_activity:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              x-internal: true
+              description: Sets the entry's economic activity (Aplifisa integration only.)
+            liquidations:
+              $ref: "#/components/schemas/RelationshipLinkageArray"
+              x-internal: true
+              description: Links the entry to existing liquidations (Aplifisa integration only.)
             items:
               type: object
               properties:
@@ -2608,6 +3470,10 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            amending_simplified_invoices:
+              $ref: "#/components/schemas/RelationshipLinkageArray"
+            amended_simplified_invoice:
+              $ref: "#/components/schemas/RelationshipLinkage"
 
     SimplifiedInvoiceWritable:
       type: object
@@ -2629,10 +3495,17 @@ components:
             number:
               type: string
               nullable: true
-              description: Full simplified invoice number including prefix.
-            filing_number:
+              description: >
+                Invoice number. For outbound (income) invoices this is the internal filing
+                number/reference; for inbound (expense) invoices this is the supplier's own
+                external reference. `complete_number` takes priority over `number` when both
+                are sent.
+            complete_number:
               type: string
               nullable: true
+              description: >
+                Full simplified invoice number including prefix, authoritative when present
+                (overrides `number` if both are sent).
             due_dates:
               type: array
               items:
@@ -2666,6 +3539,10 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            economic_activity:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              x-internal: true
+              description: Sets the entry's economic activity (Aplifisa integration only.)
             items:
               type: object
               properties:
@@ -2698,15 +3575,6 @@ components:
             notes:
               type: string
               nullable: true
-            download_pdf_url:
-              type: string
-              format: uri
-              nullable: true
-            ephemeral_open_download_pdf_url:
-              type: string
-              format: uri
-              nullable: true
-              description: Short-lived, token-authenticated PDF URL.
 
     AdditionalIncomeResource:
       type: object
@@ -2743,16 +3611,23 @@ components:
           properties:
             kind:
               type: string
-              enum: [income, expenses]
+              enum: [income]
+              description: >
+                Additional incomes are always outbound (income) documents — the API ignores
+                this field's value and always creates an `income` (outbound) entry, even if
+                `expenses` is sent.
             issue_date:
               type: string
               format: date
             number:
               type: string
               nullable: true
-            filing_number:
+            complete_number:
               type: string
               nullable: true
+              description: >
+                Full additional income number including prefix, authoritative when present
+                (overrides `number` if both are sent).
             due_dates:
               type: array
               items:
@@ -2769,15 +3644,12 @@ components:
               description: Comma-separated list of tag names (e.g. "vip client,important").
             notes:
               type: string
-            issuing_name:
-              type: string
-              description: Issuer name. Applicable when `kind` is `expenses`.
             recipient_name:
               type: string
-              description: Recipient name. Applicable when `kind` is `income`.
+              description: Recipient (customer) name.
             target_country:
               type: string
-              description: Target country code. Applicable when `kind` is `income`.
+              description: Target country code.
         relationships:
           type: object
           properties:
@@ -2789,6 +3661,10 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            economic_activity:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              x-internal: true
+              description: Sets the entry's economic activity (Aplifisa integration only.)
             items:
               type: object
               properties:
@@ -2885,6 +3761,9 @@ components:
             company_ss_amount:
               type: number
               description: Company social security amount
+            account_number_and_swift_bic:
+              type: string
+              description: Bank account number and SWIFT/BIC code
         relationships:
           type: object
           properties:
@@ -2895,6 +3774,33 @@ components:
               $ref: "#/components/schemas/RelationshipLinkage"
             accounting_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
+            project:
+              $ref: "#/components/schemas/RelationshipLinkage"
+            book_entry_draft:
+              $ref: "#/components/schemas/RelationshipLinkage"
+            attachments:
+              $ref: "#/components/schemas/RelationshipLinkageArray"
+            economic_activity:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              x-internal: true
+              description: Sets the entry's economic activity (Aplifisa integration only.)
+            liquidations:
+              $ref: "#/components/schemas/RelationshipLinkageArray"
+              x-internal: true
+              description: Links the entry to existing liquidations (Aplifisa integration only.)
+            items:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        const: items
+                      attributes:
+                        $ref: "#/components/schemas/ItemWritableAttributes"
 
     # ── Numbering Series ─────────────────────────────────────────────────
     NumberingSeriesAttributes:
@@ -3052,6 +3958,23 @@ components:
             accounting_category:
               $ref: "#/components/schemas/RelationshipLinkage"
 
+    AccountingSubcategoryUpdateWritable:
+      type: object
+      required: [type, attributes]
+      properties:
+        type:
+          type: string
+          const: accounting_subcategories
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+              example: "Office Supplies"
+            suffix:
+              type: string
+              example: "01"
+
     # ── Attachments ──────────────────────────────────────────────────────
     AttachmentResource:
       type: object
@@ -3081,6 +4004,92 @@ components:
           properties:
             book_entry:
               $ref: "#/components/schemas/RelationshipLinkage"
+
+    # ── Liquidations / Money Accounts / Money Entries (internal — Aplifisa integration only) ──
+    LiquidationResource:
+      x-internal: true
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          const: liquidations
+        attributes:
+          type: object
+          properties:
+            amount:
+              type: string
+            money_entry_id:
+              type: integer
+              nullable: true
+            book_entry_id:
+              type: integer
+              nullable: true
+            date:
+              type: string
+              format: date
+              nullable: true
+            book_entry_number:
+              type: string
+              nullable: true
+            money_account_accounting_number:
+              type: string
+              nullable: true
+            book_entry_counterpart_accounting_number:
+              type: string
+              nullable: true
+
+    MoneyAccountResource:
+      x-internal: true
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          const: money_accounts
+        attributes:
+          type: object
+          properties:
+            name:
+              type: string
+            accounting_number:
+              type: string
+              nullable: true
+            currency:
+              type: string
+              const: eur
+
+    MoneyEntryResource:
+      x-internal: true
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          const: money_entries
+        attributes:
+          type: object
+          properties:
+            concept:
+              type: string
+              nullable: true
+            amount:
+              type: string
+            transaction_date:
+              type: string
+              format: date
+              nullable: true
+            status:
+              type: string
+            money_account_id:
+              type: integer
+              nullable: true
+            money_account_accounting_number:
+              type: string
+              nullable: true
 
   # ── Responses ──────────────────────────────────────────────────────────
   responses:
@@ -3113,6 +4122,24 @@ components:
               - source:
                   pointer: /data/attributes/name
                 detail: can't be blank
+    Forbidden:
+      description: Authenticated but not authorized to perform this action
+      content:
+        application/vnd.quipu.v1+json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            errors:
+              - detail: You are not authorized to access this resource
+    BadRequest:
+      description: Malformed request (e.g. invalid parameter value)
+      content:
+        application/vnd.quipu.v1+json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            errors:
+              - detail: Bad request
     TooManyRequests:
       description: Rate limit exceeded (5 requests per 5 seconds)
       content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -455,6 +455,17 @@ paths:
           schema:
             type: string
           description: Search term for field-level query filter
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
         - name: sort
           in: query
           schema:
@@ -532,6 +543,17 @@ paths:
           schema:
             type: string
           description: Search term for field-level query filter
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of invoices
@@ -740,6 +762,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludeSimplifiedInvoice"
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of simplified invoices
@@ -876,6 +909,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludeAdditionalIncome"
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of additional income
@@ -1012,6 +1056,17 @@ paths:
         - $ref: "#/components/parameters/PageNumber"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/IncludePaysheet"
+        - name: filter[economic_activity_id]
+          in: query
+          x-internal: true
+          schema:
+            type: string
+          description: >
+            Filter by economic activity (epígrafe) ID. Accepts a numeric ID, or the sentinel
+            values `none` (only entries with no economic activity assigned) or `any` (only
+            entries with some economic activity assigned). Any other non-numeric value returns
+            an empty result rather than an error.
+            (Aplifisa integration only.)
       responses:
         "200":
           description: Paginated list of paysheets

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3979,7 +3979,7 @@ components:
         name:
           type: string
         prefix:
-          type: string
+          type: integer
         kind:
           type: string
         accounting_digits_number:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4185,6 +4185,22 @@ components:
             money_account_accounting_number:
               type: string
               nullable: true
+            accounting_category_id:
+              type: integer
+              nullable: true
+              description: Present when this money entry is reconciled directly against an accounting category (no book entry involved).
+            accounting_category_prefix:
+              type: integer
+              nullable: true
+              description: The linked accounting category's `prefix` (its accounting number).
+            linked_money_entry_id:
+              type: integer
+              nullable: true
+              description: Present when this money entry is one side of an account-to-account transfer. Points at the counterpart money entry.
+            linked_money_account_accounting_number:
+              type: string
+              nullable: true
+              description: The counterpart money entry's money account accounting number, when `linked_money_entry_id` is present.
 
   # ── Responses ──────────────────────────────────────────────────────────
   responses:

--- a/scripts/filter-internal.js
+++ b/scripts/filter-internal.js
@@ -1,10 +1,10 @@
-// Splits openapi.yaml (the source of truth, which may contain fields tagged
-// `x-internal: true`) into two artifacts:
+// Splits openapi.yaml (the source of truth, which may contain fields and
+// query parameters tagged `x-internal: true`) into two artifacts:
 //
-//   - a PUBLIC spec with every `x-internal` property removed entirely
-//     (published to GitHub Pages)
-//   - a FULL spec with every field intact, only the `x-internal` marker
-//     stripped (uploaded as a private CI artifact, e.g. for Aplifisa)
+//   - a PUBLIC spec with every `x-internal` property and parameter removed
+//     entirely (published to GitHub Pages)
+//   - a FULL spec with every field/parameter intact, only the `x-internal`
+//     marker stripped (uploaded as a private CI artifact, e.g. for Aplifisa)
 //
 // See ../README.md for the full pipeline and the reasoning behind it.
 
@@ -16,9 +16,12 @@ import yaml from 'js-yaml'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
 
-// Recursively removes any `properties` entry whose schema is tagged
-// `x-internal: true`, and drops its name from a sibling `required` array
-// if present. Mutates and returns `node`.
+// Recursively removes:
+//   - any `properties` entry whose schema is tagged `x-internal: true`
+//     (dropping its name from a sibling `required` array if present)
+//   - any entry in a `parameters` array (path-item or operation level)
+//     that is itself tagged `x-internal: true`
+// Mutates and returns `node`.
 export function removeInternalProperties(node) {
   if (Array.isArray(node)) {
     node.forEach(removeInternalProperties)
@@ -42,6 +45,12 @@ export function removeInternalProperties(node) {
     if (Array.isArray(node.required) && removedKeys.length > 0) {
       node.required = node.required.filter((key) => !removedKeys.includes(key))
     }
+  }
+
+  if (Array.isArray(node.parameters)) {
+    node.parameters = node.parameters.filter(
+      (param) => !(param && typeof param === 'object' && param['x-internal'] === true)
+    )
   }
 
   for (const value of Object.values(node)) {

--- a/scripts/filter-internal.js
+++ b/scripts/filter-internal.js
@@ -1,10 +1,12 @@
-// Splits openapi.yaml (the source of truth, which may contain fields and
-// query parameters tagged `x-internal: true`) into two artifacts:
+// Splits openapi.yaml (the source of truth, which may contain fields,
+// query parameters, and whole paths/operations tagged `x-internal: true`)
+// into two artifacts:
 //
-//   - a PUBLIC spec with every `x-internal` property and parameter removed
-//     entirely (published to GitHub Pages)
-//   - a FULL spec with every field/parameter intact, only the `x-internal`
-//     marker stripped (uploaded as a private CI artifact, e.g. for Aplifisa)
+//   - a PUBLIC spec with every `x-internal` property, parameter, and
+//     path/operation removed entirely (published to GitHub Pages)
+//   - a FULL spec with every field/parameter/path/operation intact, only
+//     the `x-internal` marker stripped (uploaded as a private CI artifact,
+//     e.g. for Aplifisa)
 //
 // See ../README.md for the full pipeline and the reasoning behind it.
 
@@ -60,6 +62,59 @@ export function removeInternalProperties(node) {
   return node
 }
 
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+
+// Drops whole `paths` entries tagged `x-internal: true` on the path item, and
+// individual operations (get/post/...) tagged `x-internal: true` when the
+// path item itself isn't fully internal. Mutates and returns `node`.
+export function removeInternalPaths(node) {
+  if (!node || typeof node !== 'object' || !node.paths || typeof node.paths !== 'object') {
+    return node
+  }
+
+  for (const [pathKey, pathItem] of Object.entries(node.paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue
+
+    if (pathItem['x-internal'] === true) {
+      delete node.paths[pathKey]
+      continue
+    }
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method]
+      if (operation && typeof operation === 'object' && operation['x-internal'] === true) {
+        delete pathItem[method]
+      }
+    }
+  }
+
+  return node
+}
+
+// Drops whole `components.schemas` / `components.parameters` /
+// `components.responses` entries tagged `x-internal: true` on the
+// definition itself (used for resources that are entirely internal, e.g.
+// a partner-only resource, as opposed to individual internal fields).
+// Mutates and returns `node`.
+export function removeInternalComponents(node) {
+  if (!node || typeof node !== 'object' || !node.components || typeof node.components !== 'object') {
+    return node
+  }
+
+  for (const section of ['schemas', 'parameters', 'responses', 'requestBodies']) {
+    const definitions = node.components[section]
+    if (!definitions || typeof definitions !== 'object') continue
+
+    for (const [name, def] of Object.entries(definitions)) {
+      if (def && typeof def === 'object' && def['x-internal'] === true) {
+        delete definitions[name]
+      }
+    }
+  }
+
+  return node
+}
+
 // Recursively deletes the `x-internal` marker key itself, leaving the
 // field it was attached to untouched. Mutates and returns `node`.
 export function stripInternalMarkers(node) {
@@ -81,11 +136,23 @@ export function stripInternalMarkers(node) {
   return node
 }
 
+// Drops top-level `tags` entries (the tag registry used for grouping in the
+// docs UI) tagged `x-internal: true`. Mutates and returns `node`.
+export function removeInternalTags(node) {
+  if (node && typeof node === 'object' && Array.isArray(node.tags)) {
+    node.tags = node.tags.filter((tag) => !(tag && typeof tag === 'object' && tag['x-internal'] === true))
+  }
+  return node
+}
+
 export function buildSpecs(sourceYaml) {
   const source = yaml.load(sourceYaml)
 
   const full = stripInternalMarkers(structuredClone(source))
-  const filtered = removeInternalProperties(structuredClone(source))
+  const filtered = removeInternalPaths(structuredClone(source))
+  removeInternalComponents(filtered)
+  removeInternalTags(filtered)
+  removeInternalProperties(filtered)
   stripInternalMarkers(filtered) // belt-and-braces: no stray markers should survive on kept fields
 
   return { full, filtered }

--- a/scripts/filter-internal.js
+++ b/scripts/filter-internal.js
@@ -115,8 +115,9 @@ export function removeInternalComponents(node) {
   return node
 }
 
-// Recursively deletes the `x-internal` marker key itself, leaving the
-// field it was attached to untouched. Mutates and returns `node`.
+// Recursively deletes the `x-internal` and `x-internal-description` marker
+// keys, leaving the field they were attached to untouched. Mutates and
+// returns `node`.
 export function stripInternalMarkers(node) {
   if (Array.isArray(node)) {
     node.forEach(stripInternalMarkers)
@@ -128,9 +129,41 @@ export function stripInternalMarkers(node) {
   }
 
   delete node['x-internal']
+  delete node['x-internal-description']
 
   for (const value of Object.values(node)) {
     stripInternalMarkers(value)
+  }
+
+  return node
+}
+
+// A field that's shared between public and internal consumers (e.g. a
+// query parameter whose allowed-values list includes an internal-only
+// value) can't be dropped wholesale like an `x-internal: true` field — it
+// still needs a public-facing description. For those, `description` holds
+// the public-safe text and a sibling `x-internal-description` holds the
+// complete text (mentioning the internal-only detail). This replaces
+// `description` with `x-internal-description` wherever both are present,
+// for use on the FULL spec only — the filtered/public spec should never
+// call this, it already has the safe text in `description`. Mutates and
+// returns `node`.
+export function applyInternalDescriptions(node) {
+  if (Array.isArray(node)) {
+    node.forEach(applyInternalDescriptions)
+    return node
+  }
+
+  if (node === null || typeof node !== 'object') {
+    return node
+  }
+
+  if (typeof node['x-internal-description'] === 'string') {
+    node.description = node['x-internal-description']
+  }
+
+  for (const value of Object.values(node)) {
+    applyInternalDescriptions(value)
   }
 
   return node
@@ -148,7 +181,7 @@ export function removeInternalTags(node) {
 export function buildSpecs(sourceYaml) {
   const source = yaml.load(sourceYaml)
 
-  const full = stripInternalMarkers(structuredClone(source))
+  const full = stripInternalMarkers(applyInternalDescriptions(structuredClone(source)))
   const filtered = removeInternalPaths(structuredClone(source))
   removeInternalComponents(filtered)
   removeInternalTags(filtered)

--- a/scripts/filter-internal.js
+++ b/scripts/filter-internal.js
@@ -169,6 +169,41 @@ export function applyInternalDescriptions(node) {
   return node
 }
 
+// After removeInternalComponents drops a whole `components.schemas` entry
+// (e.g. a partner-only resource like LiquidationResource), any `oneOf`/
+// `anyOf` list elsewhere in the doc that still `$ref`s it (e.g. a
+// polymorphic `included` items schema) is left pointing at a schema that no
+// longer exists. Prunes those dangling entries so the filtered spec stays
+// resolvable. `validSchemaNames` is the set of schema names still present
+// in `components.schemas` — call this AFTER removeInternalComponents.
+// Mutates and returns `node`.
+export function removeDanglingRefs(node, validSchemaNames) {
+  if (Array.isArray(node)) {
+    node.forEach((item) => removeDanglingRefs(item, validSchemaNames))
+    return node
+  }
+
+  if (node === null || typeof node !== 'object') {
+    return node
+  }
+
+  for (const key of ['oneOf', 'anyOf']) {
+    if (Array.isArray(node[key])) {
+      node[key] = node[key].filter((entry) => {
+        if (!entry || typeof entry !== 'object' || typeof entry.$ref !== 'string') return true
+        const match = entry.$ref.match(/^#\/components\/schemas\/(.+)$/)
+        return match ? validSchemaNames.has(match[1]) : true
+      })
+    }
+  }
+
+  for (const value of Object.values(node)) {
+    removeDanglingRefs(value, validSchemaNames)
+  }
+
+  return node
+}
+
 // Drops top-level `tags` entries (the tag registry used for grouping in the
 // docs UI) tagged `x-internal: true`. Mutates and returns `node`.
 export function removeInternalTags(node) {
@@ -186,6 +221,7 @@ export function buildSpecs(sourceYaml) {
   removeInternalComponents(filtered)
   removeInternalTags(filtered)
   removeInternalProperties(filtered)
+  removeDanglingRefs(filtered, new Set(Object.keys(filtered.components?.schemas || {})))
   stripInternalMarkers(filtered) // belt-and-braces: no stray markers should survive on kept fields
 
   return { full, filtered }

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -10,6 +10,7 @@ import {
   removeInternalComponents,
   removeInternalTags,
   stripInternalMarkers,
+  applyInternalDescriptions,
   buildSpecs
 } from './filter-internal.js'
 
@@ -145,6 +146,67 @@ test('stripInternalMarkers removes the marker but keeps the field', () => {
   stripInternalMarkers(doc)
 
   assert.deepEqual(doc.properties.secret_field, { type: 'string', description: 'shh' })
+})
+
+test('stripInternalMarkers also removes a stray x-internal-description', () => {
+  const doc = { description: 'public', 'x-internal-description': 'full' }
+
+  stripInternalMarkers(doc)
+
+  assert.deepEqual(doc, { description: 'public' })
+})
+
+test('applyInternalDescriptions swaps description for x-internal-description where present', () => {
+  const doc = {
+    name: 'include',
+    description: 'public-safe text',
+    'x-internal-description': 'full text mentioning the internal detail'
+  }
+
+  applyInternalDescriptions(doc)
+
+  assert.equal(doc.description, 'full text mentioning the internal detail')
+})
+
+test('applyInternalDescriptions leaves fields with no x-internal-description untouched', () => {
+  const doc = { name: 'plain', description: 'only description' }
+  const before = structuredClone(doc)
+
+  applyInternalDescriptions(doc)
+
+  assert.deepEqual(doc, before)
+})
+
+test('buildSpecs: public spec keeps the safe description, full spec gets the complete one, marker gone from both', () => {
+  const source = yaml.dump({
+    paths: {
+      '/things': {
+        get: {
+          parameters: [
+            {
+              name: 'include',
+              in: 'query',
+              schema: { type: 'string' },
+              description: 'Allowed values: `a`, `b`.',
+              'x-internal-description': 'Allowed values: `a`, `b`, `internal_only`.'
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  const { filtered, full } = buildSpecs(source)
+
+  const filteredParam = filtered.paths['/things'].get.parameters[0]
+  const fullParam = full.paths['/things'].get.parameters[0]
+
+  assert.equal(filteredParam.description, 'Allowed values: `a`, `b`.')
+  assert.equal(filteredParam.description.includes('internal_only'), false)
+  assert.equal('x-internal-description' in filteredParam, false)
+
+  assert.equal(fullParam.description, 'Allowed values: `a`, `b`, `internal_only`.')
+  assert.equal('x-internal-description' in fullParam, false)
 })
 
 test('buildSpecs: filtered spec has no x-internal fields and no "x-internal" strings left anywhere', () => {
@@ -298,6 +360,24 @@ test('the real openapi.yaml: no "Aplifisa" mention survives in the public spec',
   const { filtered } = buildSpecs(sourceYaml)
 
   assert.equal(JSON.stringify(filtered).toLowerCase().includes('aplifisa'), false)
+})
+
+// Structural x-internal removal only strips whole fields/parameters/paths —
+// it can't catch an internal-only concept named in plain free-text
+// `description` prose elsewhere (e.g. "liquidations" listed as an allowed
+// `include=` value on an otherwise-public parameter). This guards against
+// that leak shape specifically, independent of any single field/path.
+test('the real openapi.yaml: no internal-only concept name leaks into public description text', () => {
+  const sourcePath = path.join(__dirname, '..', 'openapi.yaml')
+  const sourceYaml = fs.readFileSync(sourcePath, 'utf8')
+
+  const { filtered, full } = buildSpecs(sourceYaml)
+
+  // Sanity check: the term must still exist in the full/internal spec —
+  // otherwise this test would pass by accident (term removed everywhere).
+  assert.ok(JSON.stringify(full).includes('liquidations'), 'expected "liquidations" to survive in the full spec')
+
+  assert.equal(JSON.stringify(filtered).includes('liquidations'), false)
 })
 
 test('removeInternalPaths drops a whole x-internal path, keeps others', () => {

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -249,7 +249,7 @@ test('the real openapi.yaml: every x-internal field disappears from the filtered
 })
 
 // Finds every (path, method, paramName) tuple tagged x-internal directly under
-// paths.*.*.parameters in the ORIGINAL doc.
+// paths.*.<http_method>.parameters in the ORIGINAL doc.
 function findTaggedParameters(sourceDoc) {
   const tuples = []
   for (const [pathKey, pathItem] of Object.entries(sourceDoc.paths || {})) {

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -9,6 +9,7 @@ import {
   removeInternalPaths,
   removeInternalComponents,
   removeInternalTags,
+  removeDanglingRefs,
   stripInternalMarkers,
   applyInternalDescriptions,
   buildSpecs
@@ -431,6 +432,103 @@ test('removeInternalComponents drops x-internal schemas/parameters/responses, ke
   assert.deepEqual(Object.keys(doc.components.schemas), ['PublicResource'])
   assert.deepEqual(Object.keys(doc.components.parameters), ['PublicParam'])
   assert.deepEqual(Object.keys(doc.components.responses), ['PublicResponse'])
+})
+
+test('removeDanglingRefs drops a oneOf entry pointing at a schema no longer present', () => {
+  const doc = {
+    components: {
+      schemas: {
+        PublicResource: { type: 'object' }
+      }
+    },
+    included: {
+      items: {
+        oneOf: [
+          { $ref: '#/components/schemas/PublicResource' },
+          { $ref: '#/components/schemas/DroppedInternalResource' }
+        ]
+      }
+    }
+  }
+
+  removeDanglingRefs(doc, new Set(Object.keys(doc.components.schemas)))
+
+  assert.deepEqual(doc.included.items.oneOf, [{ $ref: '#/components/schemas/PublicResource' }])
+})
+
+test('removeDanglingRefs leaves a oneOf list with no dangling refs unchanged', () => {
+  const doc = {
+    components: { schemas: { A: {}, B: {} } },
+    oneOf: [{ $ref: '#/components/schemas/A' }, { $ref: '#/components/schemas/B' }]
+  }
+  const before = structuredClone(doc)
+
+  removeDanglingRefs(doc, new Set(Object.keys(doc.components.schemas)))
+
+  assert.deepEqual(doc, before)
+})
+
+test('removeDanglingRefs leaves non-schema refs (e.g. parameters) alone', () => {
+  const doc = {
+    components: { schemas: {} },
+    oneOf: [{ $ref: '#/components/parameters/SomeParam' }]
+  }
+
+  removeDanglingRefs(doc, new Set())
+
+  assert.deepEqual(doc.oneOf, [{ $ref: '#/components/parameters/SomeParam' }])
+})
+
+test('buildSpecs: an internal-only schema referenced from a oneOf disappears from both the schemas map and the oneOf list in the filtered spec, survives in the full spec', () => {
+  const source = yaml.dump({
+    components: {
+      schemas: {
+        PublicResource: { type: 'object' },
+        InternalResource: { 'x-internal': true, type: 'object' }
+      }
+    },
+    paths: {
+      '/things': {
+        get: {
+          responses: {
+            '200': {
+              content: {
+                'application/json': {
+                  schema: {
+                    properties: {
+                      included: {
+                        type: 'array',
+                        items: {
+                          oneOf: [
+                            { $ref: '#/components/schemas/PublicResource' },
+                            { $ref: '#/components/schemas/InternalResource' }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const { filtered, full } = buildSpecs(source)
+
+  const filteredOneOf =
+    filtered.paths['/things'].get.responses['200'].content['application/json'].schema.properties.included.items.oneOf
+  assert.deepEqual(filteredOneOf, [{ $ref: '#/components/schemas/PublicResource' }])
+  assert.equal('InternalResource' in filtered.components.schemas, false)
+
+  const fullOneOf =
+    full.paths['/things'].get.responses['200'].content['application/json'].schema.properties.included.items.oneOf
+  assert.deepEqual(fullOneOf, [
+    { $ref: '#/components/schemas/PublicResource' },
+    { $ref: '#/components/schemas/InternalResource' }
+  ])
 })
 
 test('removeInternalTags drops only x-internal tags', () => {

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -4,7 +4,14 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import yaml from 'js-yaml'
-import { removeInternalProperties, stripInternalMarkers, buildSpecs } from './filter-internal.js'
+import {
+  removeInternalProperties,
+  removeInternalPaths,
+  removeInternalComponents,
+  removeInternalTags,
+  stripInternalMarkers,
+  buildSpecs
+} from './filter-internal.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -291,4 +298,107 @@ test('the real openapi.yaml: no "Aplifisa" mention survives in the public spec',
   const { filtered } = buildSpecs(sourceYaml)
 
   assert.equal(JSON.stringify(filtered).toLowerCase().includes('aplifisa'), false)
+})
+
+test('removeInternalPaths drops a whole x-internal path, keeps others', () => {
+  const doc = {
+    paths: {
+      '/public': { get: { summary: 'keep' } },
+      '/internal': { 'x-internal': true, get: { summary: 'drop' } }
+    }
+  }
+
+  removeInternalPaths(doc)
+
+  assert.deepEqual(Object.keys(doc.paths), ['/public'])
+})
+
+test('removeInternalPaths drops only the x-internal operation when the path itself is not tagged', () => {
+  const doc = {
+    paths: {
+      '/mixed': {
+        get: { summary: 'keep' },
+        post: { 'x-internal': true, summary: 'drop' }
+      }
+    }
+  }
+
+  removeInternalPaths(doc)
+
+  assert.deepEqual(Object.keys(doc.paths['/mixed']), ['get'])
+})
+
+test('removeInternalComponents drops x-internal schemas/parameters/responses, keeps others', () => {
+  const doc = {
+    components: {
+      schemas: {
+        PublicResource: { type: 'object' },
+        InternalResource: { 'x-internal': true, type: 'object' }
+      },
+      parameters: {
+        PublicParam: { name: 'a' },
+        InternalParam: { 'x-internal': true, name: 'b' }
+      },
+      responses: {
+        PublicResponse: { description: 'ok' },
+        InternalResponse: { 'x-internal': true, description: 'secret' }
+      }
+    }
+  }
+
+  removeInternalComponents(doc)
+
+  assert.deepEqual(Object.keys(doc.components.schemas), ['PublicResource'])
+  assert.deepEqual(Object.keys(doc.components.parameters), ['PublicParam'])
+  assert.deepEqual(Object.keys(doc.components.responses), ['PublicResponse'])
+})
+
+test('removeInternalTags drops only x-internal tags', () => {
+  const doc = {
+    tags: [
+      { name: 'Public' },
+      { name: 'Internal', 'x-internal': true }
+    ]
+  }
+
+  removeInternalTags(doc)
+
+  assert.deepEqual(doc.tags.map((t) => t.name), ['Public'])
+})
+
+test('the real openapi.yaml: every x-internal path/operation disappears from the filtered spec, survives (marker-stripped) in the full spec', () => {
+  const sourcePath = path.join(__dirname, '..', 'openapi.yaml')
+  const sourceYaml = fs.readFileSync(sourcePath, 'utf8')
+  const sourceDoc = yaml.load(sourceYaml)
+
+  const taggedPaths = Object.entries(sourceDoc.paths || {}).filter(
+    ([, item]) => item && item['x-internal'] === true
+  )
+  assert.ok(taggedPaths.length > 0, 'expected at least one x-internal path in openapi.yaml')
+
+  const { filtered, full } = buildSpecs(sourceYaml)
+
+  for (const [pathKey] of taggedPaths) {
+    assert.equal(pathKey in filtered.paths, false, `${pathKey} leaked into the public spec`)
+    assert.ok(pathKey in full.paths, `${pathKey} missing from the full spec`)
+  }
+  assert.equal(JSON.stringify(filtered).includes('x-internal'), false)
+})
+
+test('the real openapi.yaml: every x-internal schema disappears from the filtered spec, survives in the full spec', () => {
+  const sourcePath = path.join(__dirname, '..', 'openapi.yaml')
+  const sourceYaml = fs.readFileSync(sourcePath, 'utf8')
+  const sourceDoc = yaml.load(sourceYaml)
+
+  const taggedSchemas = Object.entries(sourceDoc.components?.schemas || {}).filter(
+    ([, schema]) => schema && schema['x-internal'] === true
+  )
+  assert.ok(taggedSchemas.length > 0, 'expected at least one x-internal schema in openapi.yaml')
+
+  const { filtered, full } = buildSpecs(sourceYaml)
+
+  for (const [name] of taggedSchemas) {
+    assert.equal(name in filtered.components.schemas, false, `${name} leaked into the public spec`)
+    assert.ok(name in full.components.schemas, `${name} missing from the full spec`)
+  }
 })

--- a/scripts/filter-internal.test.js
+++ b/scripts/filter-internal.test.js
@@ -22,6 +22,37 @@ test('removeInternalProperties drops only x-internal properties', () => {
   assert.deepEqual(Object.keys(doc.properties), ['public_field'])
 })
 
+test('removeInternalProperties drops only x-internal entries from a parameters array', () => {
+  const doc = {
+    get: {
+      parameters: [
+        { name: 'public_filter', in: 'query', schema: { type: 'string' } },
+        { name: 'secret_filter', in: 'query', 'x-internal': true, schema: { type: 'string' } }
+      ]
+    }
+  }
+
+  removeInternalProperties(doc)
+
+  assert.deepEqual(doc.get.parameters.map((p) => p.name), ['public_filter'])
+})
+
+test('removeInternalProperties leaves a parameters array with no internal entries unchanged', () => {
+  const doc = {
+    get: {
+      parameters: [
+        { name: 'a', in: 'query', schema: { type: 'string' } },
+        { name: 'b', in: 'query', schema: { type: 'string' } }
+      ]
+    }
+  }
+  const before = structuredClone(doc)
+
+  removeInternalProperties(doc)
+
+  assert.deepEqual(doc, before)
+})
+
 test('removeInternalProperties cleans up the required array', () => {
   const doc = {
     type: 'object',
@@ -135,6 +166,38 @@ test('buildSpecs: filtered spec has no x-internal fields and no "x-internal" str
   assert.equal(JSON.stringify(full).includes('x-internal'), false)
 })
 
+test('buildSpecs: filtered spec drops x-internal query parameters, full spec keeps them marker-stripped', () => {
+  const source = yaml.dump({
+    paths: {
+      '/things': {
+        get: {
+          parameters: [
+            { name: 'filter[open]', in: 'query', schema: { type: 'string' }, description: 'visible to everyone' },
+            {
+              name: 'filter[hidden]',
+              in: 'query',
+              'x-internal': true,
+              schema: { type: 'string' },
+              description: 'Vendor integration only.'
+            }
+          ]
+        }
+      }
+    }
+  })
+
+  const { filtered, full } = buildSpecs(source)
+
+  const filteredParams = filtered.paths['/things'].get.parameters
+  assert.deepEqual(filteredParams.map((p) => p.name), ['filter[open]'])
+  assert.equal(JSON.stringify(filtered).includes('x-internal'), false)
+
+  // full keeps both parameters, marker stripped
+  const fullParams = full.paths['/things'].get.parameters
+  assert.deepEqual(fullParams.map((p) => p.name).sort(), ['filter[hidden]', 'filter[open]'])
+  assert.equal(JSON.stringify(full).includes('x-internal'), false)
+})
+
 // Finds every (schemaName, propertyName) pair tagged x-internal directly under
 // components.schemas.*.properties in the ORIGINAL doc (field names can repeat
 // across unrelated schemas, e.g. "document_type" exists on both ContactAttributes
@@ -183,6 +246,42 @@ test('the real openapi.yaml: every x-internal field disappears from the filtered
     Object.keys(filtered.components.schemas.AccountingCategoryAttributes.properties).includes('accounting_digits_number'),
     true
   )
+})
+
+// Finds every (path, method, paramName) tuple tagged x-internal directly under
+// paths.*.*.parameters in the ORIGINAL doc.
+function findTaggedParameters(sourceDoc) {
+  const tuples = []
+  for (const [pathKey, pathItem] of Object.entries(sourceDoc.paths || {})) {
+    for (const [method, operation] of Object.entries(pathItem || {})) {
+      if (!Array.isArray(operation?.parameters)) continue
+      for (const param of operation.parameters) {
+        if (param && param['x-internal'] === true) {
+          tuples.push({ pathKey, method, paramName: param.name })
+        }
+      }
+    }
+  }
+  return tuples
+}
+
+test('the real openapi.yaml: every x-internal query parameter disappears from the filtered spec, survives in the full spec', () => {
+  const sourcePath = path.join(__dirname, '..', 'openapi.yaml')
+  const sourceYaml = fs.readFileSync(sourcePath, 'utf8')
+  const sourceDoc = yaml.load(sourceYaml)
+
+  const tagged = findTaggedParameters(sourceDoc)
+  assert.ok(tagged.length > 0, 'expected at least one x-internal query parameter in openapi.yaml')
+
+  const { filtered, full } = buildSpecs(sourceYaml)
+
+  for (const { pathKey, method, paramName } of tagged) {
+    const filteredNames = filtered.paths[pathKey][method].parameters.map((p) => p.name)
+    const fullNames = full.paths[pathKey][method].parameters.map((p) => p.name)
+
+    assert.equal(filteredNames.includes(paramName), false, `${method} ${pathKey} ${paramName} leaked into the public spec`)
+    assert.ok(fullNames.includes(paramName), `${method} ${pathKey} ${paramName} missing from the full spec`)
+  }
 })
 
 test('the real openapi.yaml: no "Aplifisa" mention survives in the public spec', () => {


### PR DESCRIPTION
## Description
Full audit of the API v1 public docs vs the real Rails app (routes, controllers, serializers, permitted params). Closes every gap found: missing endpoints, missing/stale fields, missing params, undocumented response codes, and 3 endpoints (`liquidations`, `money_accounts`, `money_entries`) that only work for accounting-integration-enabled owners — added to the internal-only spec via a new path/schema-level `x-internal` mechanism (`filter-internal.js` previously only supported field/parameter-level filtering).

Stacked on #9 (`docs/economic-activity-id-filter`) since this branch was created off it and also fills in the one gap left there (`economic_activity_epigraph` filter + missing `book_entries` coverage).

Highlights:
- Documented previously-missing endpoints: PDF download/`ephemeral_open_download` routes (invoices/simplified_invoices/additional_incomes), and internal-only `liquidations`/`money_accounts`/`money_entries`.
- Added missing fields/params across Contacts, Invoices, Paysheets, Simplified/Additional Incomes, Book Entries, Users, Accounting Categories/Subcategories.
- Fixed stale/wrong docs: `filing_number` → `complete_number` (3 schemas), `AdditionalIncome` `download_pdf_url`/`kind`/`issuing_name` contradictions, wrong `include=` values, `AccountingSubcategoryWritable` reused incorrectly for update.
- Added cross-cutting `403`/`400` responses and wired up the previously-orphaned `429`.
- Extended `filter-internal.js` with `removeInternalPaths`/`removeInternalComponents`/`removeInternalTags` (+ tests) so a whole endpoint/schema/tag can be marked internal-only, not just individual fields/params.

## Motivation and Context
- [QUI-11904](https://app.clickup.com/t/869eb13ct)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.