### PR TITLE
docs: document transfer and accounting category links on money entries [QUI-11909]

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3979,7 +3979,7 @@ components:
         name:
           type: string
         prefix:
-          type: string
+          type: integer
         kind:
           type: string
         accounting_digits_number:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4185,6 +4185,22 @@ components:
             money_account_accounting_number:
               type: string
               nullable: true
+            accounting_category_id:
+              type: integer
+              nullable: true
+              description: Present when this money entry is reconciled directly against an accounting category (no book entry involved).
+            accounting_category_prefix:
+              type: integer
+              nullable: true
+              description: The linked accounting category's `prefix` (its accounting number).
+            linked_money_entry_id:
+              type: integer
+              nullable: true
+              description: Present when this money entry is one side of an account-to-account transfer. Points at the counterpart money entry.
+            linked_money_account_accounting_number:
+              type: string
+              nullable: true
+              description: The counterpart money entry's money account accounting number, when `linked_money_entry_id` is present.
 
   # ── Responses ──────────────────────────────────────────────────────────
   responses:


### PR DESCRIPTION
## Description
Documents 2 new read-only attributes on `MoneyEntryResource` (Aplifisa-only, entire resource already `x-internal`):
- `linked_money_entry_id` / `linked_money_account_accounting_number` — account-to-account transfers
- `accounting_category_id` / `accounting_category_prefix` — money entries reconciled directly against an accounting category (no book entry)

Matches the corresponding quipuapp change on `Api::V1::MoneyEntrySerializer` (branch `QUI-11909_expose-transfers-reconciliations-api-v1`).

## Motivation and Context
- QUI-11909

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.