### PR TITLE
docs: document Aplifisa iteration 3 bulk sync + activate endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3290,8 +3290,8 @@ components:
           type: object
           required: [tax_id]
           description: >
-            Same fields as `ContactWritable.attributes` (see `POST /contacts`). `tax_id` is
-            required for every item.
+            Same fields as `ContactWritable.attributes` (see `POST /contacts`), plus the four
+            accounting-number sync fields below. `tax_id` is required for every item.
           properties:
             name:
               type: string
@@ -3326,6 +3326,39 @@ components:
               type: string
             bank_account_swift_bic:
               type: string
+            client_accounting_number:
+              type: string
+              example: "43000124"
+              description: >
+                Full accounting account code for this contact's own client account (group 4).
+                Derives `client_number` from it; the prefix must match one of the owner's valid
+                client-account prefixes for their country and its length must equal the owner's
+                `accounting_digits_number`.
+            supplier_accounting_number:
+              type: string
+              example: "40000124"
+              description: >
+                Full accounting account code for this contact's own supplier account (group 4).
+                Derives `supplier_number` (and `is_supplier_of_direct_goods`) from it; same
+                prefix/length rules as `client_accounting_number`.
+            income_accounting_number:
+              type: string
+              example: "70500124"
+              description: >
+                Full accounting account code for this contact's income counterpart account
+                (group 7). Resolves and sets the `income_category`/`income_subcategory`
+                relationships from it (creating the subcategory if it doesn't exist yet), and
+                activates that category for the owner. Prefix must match one of the owner's
+                income categories.
+            expense_accounting_number:
+              type: string
+              example: "62900124"
+              description: >
+                Full accounting account code for this contact's expense counterpart account
+                (group 6/2). Resolves and sets the `expense_category`/`expense_subcategory`
+                relationships from it (creating the subcategory if it doesn't exist yet), and
+                activates that category for the owner. Prefix must match one of the owner's
+                expense or asset categories.
             pdf_language:
               type: string
               description: Language used when rendering PDF documents for this contact.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -441,6 +441,98 @@ paths:
         "429":
           $ref: "#/components/responses/TooManyRequests"
 
+  /{owner_slug}/contacts/bulk:
+    x-internal: true
+    post:
+      operationId: bulkSyncContacts
+      summary: Bulk create/sync contacts
+      description: >
+        Only available for owners with a supported accounting-software integration enabled —
+        returns 403 otherwise. (Aplifisa integration only.) Processes every item independently;
+        a failure on one item does not affect the others. Maximum 500 items per request. After an
+        `initial` sync, the owner's default income/expense/asset accounting categories are
+        activated automatically (see `active` on `AccountingCategoryResource`).
+      tags: [Contacts]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ContentTypeHeader"
+      requestBody:
+        required: true
+        content:
+          application/vnd.quipu.v1+json:
+            schema:
+              type: object
+              required: [sync_type, data]
+              properties:
+                sync_type:
+                  type: string
+                  enum: [initial, update]
+                  description: >
+                    `initial` always creates a new contact for each item, even when a contact
+                    with the same tax_id already exists (no matching/upsert — safe to call
+                    exactly once per client during setup). `update` upserts by tax_id: updates the
+                    existing contact with that tax_id (the oldest one, if more than one somehow
+                    shares it), or creates it if none exists yet. On `update`, a field already set
+                    on the existing contact is left untouched — only blank fields are filled in.
+                data:
+                  type: array
+                  maxItems: 500
+                  items:
+                    $ref: "#/components/schemas/ContactBulkItem"
+              example:
+                sync_type: initial
+                data:
+                  - attributes:
+                      name: Acme Corp
+                      tax_id: B12345678
+                      country_code: ES
+                  - attributes:
+                      name: Wayne Enterprises
+                      tax_id: B87654321
+                      country_code: ES
+      responses:
+        "200":
+          description: >
+            Per-item results. Returned with 200 even when some items failed — check each item's
+            `status`/`errors`.
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  sync_type:
+                    type: string
+                    enum: [initial, update]
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContactBulkResultItem"
+              example:
+                sync_type: initial
+                results:
+                  - tax_id: B12345678
+                    id: "101"
+                    status: created
+                  - tax_id: B87654321
+                    id: "102"
+                    status: created
+        "400":
+          description: Malformed request — invalid `sync_type`, missing/empty `data`, or more than 500 items.
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                errors:
+                  - detail: "data cannot contain more than 500 items"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
   # ── Book Entries (read-only) ───────────────────────────────────────────
   /{owner_slug}/book_entries:
     get:
@@ -1933,6 +2025,40 @@ paths:
         "429":
           $ref: "#/components/responses/TooManyRequests"
 
+  /{owner_slug}/accounting_categories/{id}/activate:
+    x-internal: true
+    patch:
+      operationId: activateAccountingCategory
+      summary: Activate an accounting category
+      description: >
+        Only available for owners with a supported accounting-software integration enabled —
+        returns 403 otherwise. (Aplifisa integration only.) Marks the category as one of the
+        owner's active accounts (see `active` on `AccountingCategoryResource`). Idempotent, and
+        does not affect any other category.
+      tags: [Accounting Categories]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        "200":
+          description: Accounting category activated
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/AccountingCategoryResource"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
   # ── Accounting Subcategories ──────────────────────────────────────────
   /{owner_slug}/accounting_subcategories:
     get:
@@ -2110,6 +2236,88 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+
+  /{owner_slug}/accounting_subcategories/bulk:
+    x-internal: true
+    post:
+      operationId: bulkSyncAccountingSubcategories
+      summary: Bulk create/sync the chart of accounts (PGC)
+      description: >
+        Only available for owners with a supported accounting-software integration enabled —
+        returns 403 otherwise. (Aplifisa integration only.) Processes every item independently;
+        a failure on one item does not affect the others. Maximum 500 items per request. After an
+        `initial` sync, the owner's default income/expense/asset accounting categories are
+        activated automatically (see `active` on `AccountingCategoryResource`).
+      tags: [Accounting Subcategories]
+      parameters:
+        - $ref: "#/components/parameters/OwnerSlug"
+        - $ref: "#/components/parameters/AcceptHeader"
+        - $ref: "#/components/parameters/ContentTypeHeader"
+      requestBody:
+        required: true
+        content:
+          application/vnd.quipu.v1+json:
+            schema:
+              type: object
+              required: [sync_type, data]
+              properties:
+                sync_type:
+                  type: string
+                  enum: [initial, update]
+                  description: >
+                    `initial` creates a subcategory for each item and overwrites the `description`
+                    of one that already exists at that `account` code. `update` only creates
+                    subcategories that don't exist yet — an item whose `account` already exists is
+                    left untouched and reported as `skipped`.
+                data:
+                  type: array
+                  maxItems: 500
+                  items:
+                    $ref: "#/components/schemas/AccountingSubcategoryBulkItem"
+              example:
+                sync_type: initial
+                data:
+                  - attributes:
+                      account: "70501"
+                      description: Ventas de mercaderías
+      responses:
+        "200":
+          description: >
+            Per-item results. Returned with 200 even when some items failed — check each item's
+            `status`/`errors`.
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                type: object
+                properties:
+                  sync_type:
+                    type: string
+                    enum: [initial, update]
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AccountingSubcategoryBulkResultItem"
+              example:
+                sync_type: initial
+                results:
+                  - account: "70501"
+                    id: "301"
+                    status: created
+        "400":
+          description: Malformed request — invalid `sync_type`, missing/empty `data`, or more than 500 items.
+          content:
+            application/vnd.quipu.v1+json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                errors:
+                  - detail: "data cannot contain more than 500 items"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "429":
           $ref: "#/components/responses/TooManyRequests"
 
@@ -3070,6 +3278,88 @@ components:
             income_subcategory:
               $ref: "#/components/schemas/RelationshipLinkage"
               description: Default accounting subcategory applied to income documents for this contact.
+
+    ContactBulkItem:
+      x-internal: true
+      type: object
+      properties:
+        attributes:
+          type: object
+          required: [tax_id]
+          description: >
+            Same fields as `ContactWritable.attributes` (see `POST /contacts`). `tax_id` is
+            required for every item.
+          properties:
+            name:
+              type: string
+            tax_id:
+              type: string
+            phone:
+              type: string
+            email:
+              type: string
+              format: email
+            address:
+              type: string
+            town:
+              type: string
+            zip_code:
+              type: string
+            country_code:
+              type: string
+            client_number:
+              type: string
+            supplier_number:
+              type: string
+            employee_number:
+              type: string
+            a3_nom_id:
+              type: string
+            is_supplier_of_direct_goods:
+              type: boolean
+            description:
+              type: string
+            bank_account_number:
+              type: string
+            bank_account_swift_bic:
+              type: string
+            document_type:
+              type: string
+        relationships:
+          type: object
+          properties:
+            expense_category:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting category applied to expense documents for this contact.
+            expense_subcategory:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting subcategory applied to expense documents for this contact.
+            income_category:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting category applied to income documents for this contact.
+            income_subcategory:
+              $ref: "#/components/schemas/RelationshipLinkage"
+              description: Default accounting subcategory applied to income documents for this contact.
+
+    ContactBulkResultItem:
+      x-internal: true
+      type: object
+      properties:
+        tax_id:
+          type: string
+          nullable: true
+        id:
+          type: string
+          nullable: true
+          description: Present when the item succeeded.
+        status:
+          type: string
+          enum: [created, updated, error]
+        errors:
+          type: array
+          items:
+            type: string
+          description: Present only when `status` is `error`.
 
     # ── Book Entries (read-only) ─────────────────────────────────────────
     BookEntryAttributes:
@@ -4077,6 +4367,14 @@ components:
           nullable: true
           description: >
             Number of digits used in this owner's chart-of-accounts codes (e.g. 8).
+        active:
+          x-internal: true
+          type: boolean
+          description: >
+            Whether this category is one of the owner's active accounts. Set via
+            `PATCH .../accounting_categories/{id}/activate`, or automatically for the
+            owner's default categories after an initial bulk sync.
+            (Aplifisa integration only.)
 
     AccountingCategoryResource:
       type: object
@@ -4152,6 +4450,43 @@ components:
             suffix:
               type: string
               example: "01"
+
+    AccountingSubcategoryBulkItem:
+      x-internal: true
+      type: object
+      properties:
+        attributes:
+          type: object
+          required: [account]
+          properties:
+            account:
+              type: string
+              example: "70501"
+              description: >
+                Full accounting account code. Its prefix must match an existing accounting
+                category for this owner.
+            description:
+              type: string
+              example: Ventas de mercaderías
+
+    AccountingSubcategoryBulkResultItem:
+      x-internal: true
+      type: object
+      properties:
+        account:
+          type: string
+        id:
+          type: string
+          nullable: true
+          description: Present when the item succeeded.
+        status:
+          type: string
+          enum: [created, updated, skipped, error]
+        errors:
+          type: array
+          items:
+            type: string
+          description: Present only when `status` is `error`.
 
     # ── Attachments ──────────────────────────────────────────────────────
     AttachmentResource:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -478,6 +478,7 @@ paths:
                 data:
                   type: array
                   maxItems: 500
+                  minItems: 1
                   items:
                     $ref: "#/components/schemas/ContactBulkItem"
               example:
@@ -2274,6 +2275,7 @@ paths:
                 data:
                   type: array
                   maxItems: 500
+                  minItems: 1
                   items:
                     $ref: "#/components/schemas/AccountingSubcategoryBulkItem"
               example:
@@ -3282,6 +3284,7 @@ components:
     ContactBulkItem:
       x-internal: true
       type: object
+      required: [attributes]
       properties:
         attributes:
           type: object
@@ -3323,6 +3326,27 @@ components:
               type: string
             bank_account_swift_bic:
               type: string
+            pdf_language:
+              type: string
+              description: Language used when rendering PDF documents for this contact.
+            incomes_due_date:
+              type: string
+              description: Default due-date preference applied to income documents issued to this contact.
+            incomes_payment_method:
+              type: string
+              description: Default payment method applied to income documents issued to this contact.
+            equivalence_subcharge:
+              type: boolean
+              description: Whether equivalence surcharge applies by default for this contact.
+            expenses_payment_method:
+              type: string
+              description: Default payment method applied to expense documents received from this contact.
+            expenses_due_date:
+              type: string
+              description: Default due-date preference applied to expense documents received from this contact.
+            contact_analytic_value_ids:
+              type: string
+              description: Comma-separated list of analytic value IDs to associate with the contact (e.g. "12,34").
             document_type:
               type: string
         relationships:
@@ -4454,6 +4478,7 @@ components:
     AccountingSubcategoryBulkItem:
       x-internal: true
       type: object
+      required: [attributes]
       properties:
         attributes:
           type: object


### PR DESCRIPTION
## Description
Documents the 3 endpoints from the Aplifisa "initial setup" iteration (backend: quipuapp/quipuapp#11668) that were implemented but never made it into the spec:

- `POST /{owner_slug}/contacts/bulk` — bulk create/sync contacts (`sync_type=initial|update`, max 500 items).
- `POST /{owner_slug}/accounting_subcategories/bulk` — bulk create/sync the chart of accounts / PGC (`sync_type=initial|update`, max 500 items).
- `PATCH /{owner_slug}/accounting_categories/{id}/activate` — manually activate an accounting category.

Also documents the `active` attribute on `AccountingCategoryResource`, which backs the activation endpoint (and is set automatically for default categories after an `initial` bulk sync).

All new paths/schemas/properties are marked `x-internal: true`, following the existing `Liquidations`/`Money Accounts`/`Money Entries`/`Economic Activities` pattern — internal-only, stripped from the public spec, only present in the `openapi-full` artifact sent to Aplifisa.

`ContactBulkItem.attributes` also documents the 4 accounting-number sync fields (`client_accounting_number`, `supplier_accounting_number`, `income_accounting_number`, `expense_accounting_number`) — real fields the bulk endpoint processes via `Contact#parse_accounting_numbers`, same as create/update, that were missing from the schema (caught in review). Still out of scope: the matching read-back fields on `ContactResource`/`ContactWritable` (`income_account_code`/`expense_account_code`/`supplier_account_code` + category relationships) — that gap predates this PR (QUI-11600) and isn't specific to iteration 3 or to Aplifisa, so it needs its own review rather than riding along here. Happy to open that as a follow-up if wanted.

Note on `sync_type` semantics, since it's not obvious from the endpoint names and differs between the two bulk endpoints:
- Contacts: `initial` always creates (even on a duplicate tax_id); `update` upserts by tax_id.
- Accounting subcategories: `initial` overwrites existing accounts; `update` skips ones that already exist.

Verified against the repo's own filter: `npm test` passes (27/27, including the two tests that check the real `openapi.yaml`), and a manual `buildSpecs()` run confirms all 3 new paths + the `active` field appear in the full/Aplifisa spec and are absent from the public one.

## ⚠️ Known issue — NOT fixed by this PR (backend)

Review caught that the doc's `403` promise ("Only available for owners with a supported accounting-software integration enabled — returns 403 otherwise") only actually holds for **one of the three** endpoints:

- `PATCH .../accounting_categories/{id}/activate` — gated correctly (`accounting_categories_controller.rb:5`, `before_action :require_aplifisa_integration!, only: [:activate]`; covered by a 403 test).
- `POST .../contacts/bulk` — **not gated**. Only goes through the normal `authorize! :create, Contact.new(owner: owner)` ability check — any owner (Aplifisa or not) can call it today.
- `POST .../accounting_subcategories/bulk` — **not gated**, same issue.

`x-internal: true` (already applied to all three in this PR) only controls whether the endpoint appears in the *published documentation* — it has no effect on what the API actually accepts at runtime. So today, marking these internal correctly hides them from the public docs site, but does not stop a non-Aplifisa owner's own API credentials from hitting `/contacts/bulk` or `/accounting_subcategories/bulk`.

Per team decision, backend is not being touched in this PR. Fix is small (same `before_action :require_aplifisa_integration!` pattern already used on `activate`), tracked separately. The doc text still describes the *intended* contract, which is accurate for Aplifisa's own usage (their owners do have the integration enabled) — this note is so the gap doesn't get lost before it reaches other, non-Aplifisa callers.

## Motivation and Context
- Related backend PRs: quipuapp/quipuapp#11668, #11658, #11666, #11678, #11683

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes (existing `filter-internal.test.js` suite passes against the updated spec)
