### PR TITLE
docs: document preserved_fields on contacts bulk sync result [QUI-12047]

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3417,6 +3417,15 @@ components:
           items:
             type: string
           description: Present only when `status` is `error`.
+        preserved_fields:
+          type: array
+          items:
+            type: string
+          description: >-
+            Present when `status` is `updated`. Names of the fields sent in this
+            item that were NOT applied because the contact already had a value
+            for them (Quipu edits win over a re-sync). Empty when nothing was
+            skipped.
 
     # ── Book Entries (read-only) ─────────────────────────────────────────
     BookEntryAttributes:


### PR DESCRIPTION

## Description
Adds `preserved_fields` to `ContactBulkResultItem` in the contacts bulk sync response — the array of field names sent by the caller but not applied because the contact already had a value set (re-sync never clobbers a Quipu edit).

## Motivation and Context
- [QUI-12047](https://app.clickup.com/t/869ejykkd)
Backend change: https://github.com/quipuapp/quipuapp/pull/11840

Based on top of `docs/aplifisa-iteration-3-bulk-endpoints` since that's where `/contacts/bulk` is documented and not yet merged.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.